### PR TITLE
Hotfix: Docker push / Codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --all-features --timeout 120 --out Xml
+          cargo tarpaulin --ignored --verbose --all-features --timeout 120 --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,9 +17,6 @@ env:
 
 jobs:
   push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 


### PR DESCRIPTION
This is a hotfix that fixed the codecov report not including the "ignored" tests. It also fixes the docker build and push action to the image registry.