### PR TITLE
merge: Add changes from 0.5.0 dev to dev branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aruna_server"
-version = "0.5.0-beta.8"
+version = "0.5.0-beta.9"
 dependencies = [
  "aruna-rust-api",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ name = "aruna_server"
 version = "0.5.0"
 dependencies = [
  "aruna-rust-api",
+ "bigdecimal",
  "chrono",
  "diesel",
  "diesel-derive-enum",
@@ -162,6 +163,17 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "bitflags"
@@ -313,11 +325,15 @@ version = "2.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a12f2d98c35d1dfaf74083664be5bb71606b72f4756f3792cdb1ddb192b46"
 dependencies = [
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
  "itoa",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "pq-sys",
  "r2d2",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "aruna-rust-api"
-version = "0.5.0-beta.7"
+version = "0.5.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf130fc3a38c8293ea2470e3682da97bb5fb6359f770df67367bf39b8c136fbc"
+checksum = "ee07508e712e71c148951888fb89847dfc2d22c8422f5d6bcfa9e3eac507e06b"
 dependencies = [
  "prost",
  "prost-types",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aruna_server"
-version = "0.5.0-beta.7"
+version = "0.5.0-beta.8"
 dependencies = [
  "aruna-rust-api",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "aruna-rust-api"
-version = "0.5.0-beta.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3de69fc6f2c586c1572dcc1077bfd13d5e92aaf1cfbf2623835ed011703f4"
+checksum = "918c8b1e2d8aba155bffc2acc29c65251ebf89e7f7215c63680aa884cf928494"
 dependencies = [
  "prost",
  "prost-types",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aruna_server"
-version = "0.5.0-beta.9"
+version = "0.5.0"
 dependencies = [
  "aruna-rust-api",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "aruna-rust-api"
-version = "0.5.0-beta.8"
+version = "0.5.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee07508e712e71c148951888fb89847dfc2d22c8422f5d6bcfa9e3eac507e06b"
+checksum = "ced3de69fc6f2c586c1572dcc1077bfd13d5e92aaf1cfbf2623835ed011703f4"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "aruna_server"
-version = "0.5.0-beta.8"
+version = "0.5.0-beta.9"
 description = "Server application for AOS (Aruna Object Storage)"
 repository = "https://github.com/ArunaStorage/ArunaServer"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.41"
 toml = "0.5.9"
-aruna-rust-api = "0.5.0-beta.8"
+aruna-rust-api = "0.5.0-beta.9"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "aruna_server"
-version = "0.5.0-beta.7"
+version = "0.5.0-beta.8"
 description = "Server application for AOS (Aruna Object Storage)"
 repository = "https://github.com/ArunaStorage/ArunaServer"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ serde_json = "1.0"
 reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.41"
 toml = "0.5.9"
-aruna-rust-api = "0.5.0-beta.7"
+aruna-rust-api = "0.5.0-beta.8"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "aruna_server"
-version = "0.5.0-beta.9"
+version = "0.5.0"
 description = "Server application for AOS (Aruna Object Storage)"
 repository = "https://github.com/ArunaStorage/ArunaServer"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ serde_json = "1.0"
 reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.41"
 toml = "0.5.9"
-aruna-rust-api = "0.5.0-beta.9"
+aruna-rust-api = "0.5.0"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 chrono = "0.4.22"
-diesel = {version = "2.0.0-rc.1", features = ["postgres", "uuid", "r2d2", "chrono"]}
+diesel = {version = "2.0.0-rc.1", features = ["postgres", "uuid", "r2d2", "chrono", "numeric"]}
 diesel-derive-enum = { version = "2.0.0-rc.0", features = ["postgres"] }
 dotenv = "0.15.0"
 http = "0.2.8"
@@ -33,6 +33,7 @@ reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.41"
 toml = "0.5.9"
 aruna-rust-api = "0.5.0"
+bigdecimal = "0.3.0"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/config/config.toml
+++ b/config/config.toml
@@ -7,3 +7,9 @@ endpoint_name   = 'Default Data Proxy'
 endpoint_proxy  = 'http://localhost:8081'
 endpoint_host   = 'http://localhost:8081'
 endpoint_public = true
+
+[loc_version]
+location        = 'FOO'
+components = [
+  { component_name = 'Bar', semver = {major = 0, minor = 1, patch = 0, labels = ''} }
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,9 +35,9 @@ pub struct DefaultEndpoint {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SemVer {
-    pub major: i64,
-    pub minor: i64,
-    pub patch: i64,
+    pub major: i32,
+    pub minor: i32,
+    pub patch: i32,
     pub labels: String,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub database_url: String,
     pub oauth_realminfo: String,
     pub default_endpoint: DefaultEndpoint,
+    pub loc_version: LocationVersion,
 }
 #[derive(Clone, Debug, Deserialize)]
 pub struct DefaultEndpoint {
@@ -30,6 +31,26 @@ pub struct DefaultEndpoint {
     pub endpoint_proxy: String,
     pub endpoint_public: bool,
     pub endpoint_docu: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SemVer {
+    pub major: i64,
+    pub minor: i64,
+    pub patch: i64,
+    pub labels: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ComponentVersion {
+    pub component_name: String,
+    pub semver: SemVer,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct LocationVersion {
+    pub location: String,
+    pub components: Vec<ComponentVersion>,
 }
 
 ///

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -397,7 +397,7 @@ impl Database {
                         created_by: user_id,
                         version_id: Some(new_version.id),
                         dataclass: Some(request.dataclass()).map(DBDataclass::from),
-                        project_id: uuid::Uuid::parse_str(&request.project_id)?,
+                        project_id: old_collection.project_id,
                     };
                     // Execute the pin request and return the collection overview
 

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -20,7 +20,7 @@ use crate::database::models::enums::{Dataclass as DBDataclass, KeyValueType, Ref
 use crate::database::models::object::{Object, ObjectKeyValue};
 use crate::database::models::object_group::{ObjectGroup, ObjectGroupKeyValue, ObjectGroupObject};
 use crate::database::models::views::CollectionStat;
-use crate::error::ArunaError;
+use crate::error::{ArunaError, TypeConversionError};
 use aruna_rust_api::api::storage::models::v1::DataClass;
 use aruna_rust_api::api::storage::models::v1::{
     collection_overview, collection_overview::Version as CollectionVersiongRPC, CollectionOverview,
@@ -32,6 +32,7 @@ use aruna_rust_api::api::storage::services::v1::{
     GetCollectionsRequest, GetCollectionsResponse, PinCollectionVersionRequest,
     PinCollectionVersionResponse, UpdateCollectionRequest, UpdateCollectionResponse,
 };
+use bigdecimal::ToPrimitive;
 use chrono::Local;
 use diesel::r2d2::ConnectionManager;
 use diesel::result::Error;
@@ -744,7 +745,9 @@ fn map_to_collection_overview(
             if let Some(sts) = ret_coll.coll_stats {
                 let obj_stats = Stats {
                     count: sts.object_count,
-                    acc_size: sts.size,
+                    acc_size: sts.size.to_i64().ok_or(ArunaError::TypeConversionError(
+                        TypeConversionError::BIGDECIMAL,
+                    ))?,
                 };
 
                 let coll_stats = CollectionStats {

--- a/src/database/crud/info.rs
+++ b/src/database/crud/info.rs
@@ -1,13 +1,12 @@
-use aruna_rust_api::api::storage::models::v1::{Permission, ResourceType};
+use aruna_rust_api::api::storage::models::v1::ResourceType;
 use aruna_rust_api::api::storage::services::v1::{
     GetResourceHierarchyRequest, GetResourceHierarchyResponse, Hierarchy,
 };
-use diesel::dsl::date;
-use diesel::{prelude::*, sql_query, QueryDsl, RunQueryDsl};
+use diesel::{prelude::*, QueryDsl, RunQueryDsl};
 
 use crate::database;
 use crate::database::connection::Database;
-use crate::database::models::auth::{ApiToken, UserPermission};
+use crate::database::models::auth::ApiToken;
 use crate::database::models::collection::{Collection, CollectionObject, CollectionObjectGroup};
 use crate::database::models::object_group::ObjectGroupObject;
 use crate::error::ArunaError;
@@ -28,7 +27,7 @@ impl Database {
         let parsed_resource = uuid::Uuid::parse_str(&request.resource_id)?;
 
         // Check if endpoint defined in the config already exists in the database
-        let hierarchy = self
+        let _hierarchy = self
             .pg_connection
             .get()?
             .transaction::<Vec<Hierarchy>, ArunaError, _>(|conn| {
@@ -44,7 +43,7 @@ impl Database {
                     .first::<ApiToken>(conn)?;
 
                 // Check if token is scoped and use this scope
-                let scope = match api_token.collection_id {
+                let _scope = match api_token.collection_id {
                     Some(coll) => Scoped::COLLECTIONID(coll),
                     None => match api_token.project_id {
                         Some(proj) => Scoped::PROJECTID(proj),
@@ -78,7 +77,7 @@ impl Database {
                         }]
                     }
                     ResourceType::Object => {
-                        let coll_objects = collection_objects
+                        let _coll_objects = collection_objects
                             .filter(
                                 database::schema::collection_objects::object_id
                                     .eq(&parsed_resource),
@@ -136,7 +135,7 @@ impl Database {
                             .filter(database::schema::collections::id.eq_any(&coll_ids))
                             .load::<Collection>(conn)?;
 
-                        let col_projs = colls
+                        let _col_projs = colls
                             .iter()
                             .map(|col| (col.project_id, col.id))
                             .collect::<Vec<(uuid::Uuid, uuid::Uuid)>>();

--- a/src/database/crud/info.rs
+++ b/src/database/crud/info.rs
@@ -2,12 +2,16 @@ use aruna_rust_api::api::storage::models::v1::{Permission, ResourceType};
 use aruna_rust_api::api::storage::services::v1::{
     GetResourceHierarchyRequest, GetResourceHierarchyResponse, Hierarchy,
 };
+use diesel::dsl::date;
 use diesel::{prelude::*, sql_query, QueryDsl, RunQueryDsl};
 
 use crate::database;
 use crate::database::connection::Database;
 use crate::database::models::auth::{ApiToken, UserPermission};
+use crate::database::models::collection::{Collection, CollectionObject, CollectionObjectGroup};
+use crate::database::models::object_group::ObjectGroupObject;
 use crate::error::ArunaError;
+use itertools::Itertools;
 
 impl Database {
     pub fn validate_and_query_hierarchy(
@@ -16,6 +20,13 @@ impl Database {
         token_id: uuid::Uuid,
     ) -> Result<GetResourceHierarchyResponse, ArunaError> {
         use crate::database::schema::api_tokens::dsl::*;
+        use crate::database::schema::collection_object_groups::dsl::*;
+        use crate::database::schema::collection_objects::dsl::*;
+        use crate::database::schema::collections::dsl::*;
+        use crate::database::schema::object_group_objects::dsl::*;
+
+        let parsed_resource = uuid::Uuid::parse_str(&request.resource_id)?;
+
         // Check if endpoint defined in the config already exists in the database
         let hierarchy = self
             .pg_connection
@@ -41,31 +52,103 @@ impl Database {
                     },
                 };
 
-                match request.resource_type() {
+                let hierarchies = match request.resource_type() {
                     ResourceType::Unspecified | ResourceType::All => {
                         return Err(ArunaError::InvalidRequest(
                             "ResourceType must be specified".to_string(),
                         ))
                     }
                     ResourceType::Project => {
-                        if scope == Scoped::PROJECTID(uuid::Uuid::parse_str(&request.resource_id)?)
-                        {
-                            return Ok(vec![Hierarchy {
-                                object_id: "".to_string(),
-                                object_group_ids: vec!["".to_string()],
-                                collection_id: "".to_string(),
-                                project_id: request.resource_id,
-                            }]);
-                        } else {
-                            
-                        }
+                        vec![Hierarchy {
+                            object_id: "".to_string(),
+                            object_group_ids: vec!["".to_string()],
+                            collection_id: "".to_string(),
+                            project_id: parsed_resource.to_string(),
+                        }]
                     }
-                    ResourceType::Collection => {}
-                    ResourceType::Object => {}
-                    ResourceType::ObjectGroup => {}
-                }
+                    ResourceType::Collection => {
+                        let get_coll = collections
+                            .filter(database::schema::collections::id.eq(&parsed_resource))
+                            .first::<Collection>(conn)?;
+                        vec![Hierarchy {
+                            object_id: "".to_string(),
+                            object_group_ids: vec!["".to_string()],
+                            collection_id: get_coll.id.to_string(),
+                            project_id: get_coll.project_id.to_string(),
+                        }]
+                    }
+                    ResourceType::Object => {
+                        let coll_objects = collection_objects
+                            .filter(
+                                database::schema::collection_objects::object_id
+                                    .eq(&parsed_resource),
+                            )
+                            .load::<CollectionObject>(conn)?;
+                        let object_grp_objects = object_group_objects
+                            .filter(
+                                database::schema::object_group_objects::object_id
+                                    .eq(&parsed_resource),
+                            )
+                            .load::<ObjectGroupObject>(conn)
+                            .optional()?;
 
-                Ok(())
+                        // Vec with object_group id / object_id
+                        let obj_group_ids = object_grp_objects.map(|grps| {
+                            grps.iter()
+                                .map(|grp| (grp.object_group_id, grp.object_id))
+                                .collect::<Vec<(uuid::Uuid, uuid::Uuid)>>()
+                        });
+
+                        // Vec with coll_id & object_group_id
+                        let coll_obj_ids = match obj_group_ids {
+                            Some(ogroup_tuple) => {
+                                let ogroup_ids = ogroup_tuple
+                                    .iter()
+                                    .map(|(og, _)| og.to_owned())
+                                    .collect::<Vec<uuid::Uuid>>();
+
+                                match collection_object_groups
+                                    .filter(
+                                        database::schema::collection_object_groups::object_group_id
+                                            .eq_any(&ogroup_ids),
+                                    )
+                                    .load::<CollectionObjectGroup>(conn)
+                                    .optional()?
+                                {
+                                    Some(grp) => grp
+                                        .iter()
+                                        .map(|grp| (grp.collection_id, grp.object_group_id))
+                                        .collect::<Vec<(uuid::Uuid, uuid::Uuid)>>(),
+                                    None => Vec::new(),
+                                }
+                            }
+                            None => Vec::new(),
+                        };
+
+                        // Get collections
+                        let coll_ids = coll_obj_ids
+                            .iter()
+                            .map(|(coll, _)| coll.to_owned())
+                            .unique()
+                            .collect::<Vec<uuid::Uuid>>();
+
+                        let colls = collections
+                            .filter(database::schema::collections::id.eq_any(&coll_ids))
+                            .load::<Collection>(conn)?;
+
+                        let col_projs = colls
+                            .iter()
+                            .map(|col| (col.project_id, col.id))
+                            .collect::<Vec<(uuid::Uuid, uuid::Uuid)>>();
+
+                        todo!()
+                    }
+                    ResourceType::ObjectGroup => {
+                        todo!()
+                    }
+                };
+
+                Ok(hierarchies)
             });
 
         todo!()

--- a/src/database/crud/info.rs
+++ b/src/database/crud/info.rs
@@ -33,9 +33,9 @@ impl Database {
             .transaction::<Vec<Hierarchy>, ArunaError, _>(|conn| {
                 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
                 enum Scoped {
-                    COLLECTIONID(uuid::Uuid),
-                    PROJECTID(uuid::Uuid),
-                    NONE,
+                    Collectionid(uuid::Uuid),
+                    Projectid(uuid::Uuid),
+                    None,
                 }
 
                 let api_token = api_tokens
@@ -44,10 +44,10 @@ impl Database {
 
                 // Check if token is scoped and use this scope
                 let _scope = match api_token.collection_id {
-                    Some(coll) => Scoped::COLLECTIONID(coll),
+                    Some(coll) => Scoped::Collectionid(coll),
                     None => match api_token.project_id {
-                        Some(proj) => Scoped::PROJECTID(proj),
-                        None => Scoped::NONE,
+                        Some(proj) => Scoped::Projectid(proj),
+                        None => Scoped::None,
                     },
                 };
 

--- a/src/database/crud/info.rs
+++ b/src/database/crud/info.rs
@@ -1,0 +1,58 @@
+use aruna_rust_api::api::storage::models::v1::Permission;
+use aruna_rust_api::api::storage::services::v1::{
+    GetResourceHierarchyRequest, GetResourceHierarchyResponse,
+};
+use diesel::{prelude::*, sql_query, QueryDsl, RunQueryDsl};
+
+use crate::database;
+use crate::database::connection::Database;
+use crate::database::models::auth::{ApiToken, UserPermission};
+use crate::error::ArunaError;
+
+impl Database {
+    pub fn validate_and_query_hierarchy(
+        &self,
+        request: GetResourceHierarchyRequest,
+        token_id: uuid::Uuid,
+    ) -> Result<GetResourceHierarchyResponse, ArunaError> {
+        use crate::database::schema::api_tokens::dsl::*;
+        // Check if endpoint defined in the config already exists in the database
+        let hierarchy = self
+            .pg_connection
+            .get()?
+            .transaction::<_, ArunaError, _>(|conn| {
+                enum Scoped {
+                    COLLECTIONID(uuid::Uuid),
+                    PROJECTID(uuid::Uuid),
+                    NONE,
+                }
+
+                let api_token = api_tokens
+                    .filter(database::schema::api_tokens::id.eq(token_id))
+                    .first::<ApiToken>(conn)?;
+
+                let project_ids = Vec::new();
+
+                // Check if token is scoped and use this scope
+                let scope = match api_token.collection_id {
+                    Some(coll) => Scoped::COLLECTIONID(coll),
+                    None => match api_token.project_id {
+                        Some(proj) => Scoped::PROJECTID(proj),
+                        None => Scoped::NONE,
+                    },
+                };
+
+                let permissions = match scope {
+                    Scoped::COLLECTIONID(coll) => {
+
+                    }
+                    Scoped::PROJECTID(proj) => {}
+                    Scoped::NONE => {}
+                }
+
+                Ok(())
+            });
+
+        todo!()
+    }
+}

--- a/src/database/crud/mod.rs
+++ b/src/database/crud/mod.rs
@@ -2,6 +2,7 @@ pub mod authz;
 pub mod collection;
 pub mod cron;
 pub mod endpoint;
+pub mod info;
 pub mod object;
 pub mod objectgroups;
 pub mod project;

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -36,8 +36,8 @@ use aruna_rust_api::api::storage::{
 use crate::database;
 use crate::database::connection::Database;
 use crate::database::crud::utils::{
-    check_all_for_db_kv, db_to_grpc_object_status, from_key_values, naivedatetime_to_prost_time,
-    parse_page_request, parse_query, to_key_values,
+    check_all_for_db_kv, db_to_grpc_dataclass, db_to_grpc_object_status, from_key_values,
+    naivedatetime_to_prost_time, parse_page_request, parse_query, to_key_values,
 };
 use crate::database::models::collection::CollectionObject;
 use crate::database::models::enums::{
@@ -2064,7 +2064,7 @@ impl TryFrom<ObjectDto> for ProtoObject {
             content_len: object_dto.object.content_len,
             status: db_to_grpc_object_status(object_dto.object.object_status) as i32,
             origin: proto_origin,
-            data_class: object_dto.object.dataclass as i32,
+            data_class: db_to_grpc_dataclass(&object_dto.object.dataclass) as i32,
             hash: Some(proto_hash),
             rev_number: object_dto.object.revision_number,
             source: proto_source,

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -578,6 +578,13 @@ impl Database {
                     // Get latest revision of the Object to be updated
                     let latest = get_latest_obj(conn, parsed_old_id)?;
 
+                    if latest.id != parsed_old_id && !request.force {
+                        return Err(ArunaError::InvalidRequest(
+                            "Concurrency error: Updates without force are only allowed for the latest object"
+                                .to_string(),
+                        ));
+                    }
+
                     //Define source object from updated request; None if empty
                     let source: Option<Source> = match &sobj.source {
                         Some(source) => Some(Source {

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -14,9 +14,9 @@ use crate::database::models::object_group::ObjectGroupObject;
 use crate::error::{ArunaError, GrpcNotFoundError};
 use aruna_rust_api::api::internal::v1::{Location as ProtoLocation, LocationType};
 use aruna_rust_api::api::storage::services::v1::{
-    AddLabelToObjectRequest, AddLabelToObjectResponse, DeleteObjectsRequest, DeleteObjectsResponse,
-    GetReferencesRequest, GetReferencesResponse, ObjectReference, SetHooksOfObjectRequest,
-    SetHooksOfObjectResponse,
+    AddLabelsToObjectRequest, AddLabelsToObjectResponse, DeleteObjectsRequest,
+    DeleteObjectsResponse, GetReferencesRequest, GetReferencesResponse, ObjectReference,
+    SetHooksOfObjectRequest, SetHooksOfObjectResponse,
 };
 use aruna_rust_api::api::storage::{
     models::v1::{
@@ -1375,10 +1375,10 @@ impl Database {
     }
 
     /// ToDo: Rust Doc
-    pub fn add_label_to_object(
+    pub fn add_labels_to_object(
         &self,
-        request: AddLabelToObjectRequest,
-    ) -> Result<AddLabelToObjectResponse, ArunaError> {
+        request: AddLabelsToObjectRequest,
+    ) -> Result<AddLabelsToObjectResponse, ArunaError> {
         let parsed_object_id = uuid::Uuid::parse_str(&request.object_id)?;
         let parsed_collection_id = uuid::Uuid::parse_str(&request.collection_id)?;
         // Transaction time
@@ -1403,7 +1403,7 @@ impl Database {
             .map(|e| e.try_into())
             .map_or(Ok(None), |r| r.map(Some))?;
 
-        Ok(AddLabelToObjectResponse { object: mapped })
+        Ok(AddLabelsToObjectResponse { object: mapped })
     }
 
     /// ToDo: Rust Doc

--- a/src/database/crud/objectgroups.rs
+++ b/src/database/crud/objectgroups.rs
@@ -26,6 +26,7 @@ use aruna_rust_api::api::storage::{
         UpdateObjectGroupResponse,
     },
 };
+use bigdecimal::ToPrimitive;
 use chrono::Utc;
 use diesel::{delete, insert_into, prelude::*, r2d2::ConnectionManager, result::Error, update};
 use itertools::Itertools;
@@ -939,7 +940,7 @@ impl From<ObjectGroupDb> for ObjectGroupOverview {
         let stats = ogroup_db.stats.map(|ogstats| ObjectGroupStats {
             object_stats: Some(Stats {
                 count: ogstats.object_count,
-                acc_size: ogstats.size,
+                acc_size: ogstats.size.to_i64().unwrap_or_default(),
             }),
             last_updated: Some(
                 naivedatetime_to_prost_time(ogstats.last_updated).unwrap_or_default(),

--- a/src/database/crud/user.rs
+++ b/src/database/crud/user.rs
@@ -510,6 +510,8 @@ impl Database {
                         .to_string(),
                     project_id: elem.project_id.to_string(),
                     permission: map_permissions_rev(Some(elem.user_right)),
+                    // TODO: check for service account
+                    service_account: false,
                 })
                 .collect::<Vec<_>>(),
         })

--- a/src/database/crud/utils.rs
+++ b/src/database/crud/utils.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use chrono::{Datelike, Timelike};
 use uuid::Uuid;
 
-use aruna_rust_api::api::storage::models::v1::{KeyValue, LabelOrIdQuery, PageRequest, Status};
+use aruna_rust_api::api::storage::models::v1::{
+    DataClass, KeyValue, LabelOrIdQuery, PageRequest, Status,
+};
 
 use crate::database::models::enums::{Dataclass, KeyValueType, ObjectStatus, UserRights};
 use crate::database::models::traits::{IsKeyValue, ToDbKeyValue};
@@ -402,6 +404,15 @@ pub fn grpc_to_db_dataclass(grpcdclass: &i32) -> Dataclass {
     }
 }
 
+pub fn db_to_grpc_dataclass(db_dataclass: &Dataclass) -> DataClass {
+    match db_dataclass {
+        Dataclass::PUBLIC => DataClass::Public,
+        Dataclass::PRIVATE => DataClass::Private,
+        Dataclass::CONFIDENTIAL => DataClass::Confidential,
+        Dataclass::PROTECTED => DataClass::Protected,
+    }
+}
+
 pub fn grpc_to_db_object_status(grpc_status: &i32) -> ObjectStatus {
     match grpc_status {
         0 => ObjectStatus::ERROR, // Unspecified is not good
@@ -430,9 +441,9 @@ mod tests {
     use super::*;
     use crate::database::models::collection::CollectionKeyValue;
     use crate::database::models::object::ObjectKeyValue;
-    use aruna_rust_api::api::storage::models::v1::KeyValue;
     use aruna_rust_api::api::storage::models::v1::LabelFilter;
     use aruna_rust_api::api::storage::models::v1::Permission;
+    use aruna_rust_api::api::storage::models::v1::{DataClass, KeyValue};
     use std::any::type_name;
 
     #[test]
@@ -937,6 +948,59 @@ mod tests {
         assert_eq!(hits.clone().unwrap().len(), 2);
         assert!(hits.clone().unwrap().contains(&id_non_hit));
         assert!(hits.unwrap().contains(&id_hit));
+    }
+
+    #[test]
+    fn test_grpc_to_db_dataclass() {
+        for grpc_dataclass in vec![
+            DataClass::Unspecified as i32,
+            DataClass::Public as i32,
+            DataClass::Private as i32,
+            DataClass::Confidential as i32,
+            DataClass::Protected as i32,
+            12345, // Some index that does not exist
+        ]
+        .iter()
+        {
+            match grpc_dataclass {
+                0 => assert_eq!(grpc_to_db_dataclass(grpc_dataclass), Dataclass::PRIVATE),
+                1 => assert_eq!(grpc_to_db_dataclass(grpc_dataclass), Dataclass::PUBLIC),
+                2 => assert_eq!(grpc_to_db_dataclass(grpc_dataclass), Dataclass::PRIVATE),
+                3 => assert_eq!(
+                    grpc_to_db_dataclass(grpc_dataclass),
+                    Dataclass::CONFIDENTIAL
+                ),
+                4 => assert_eq!(grpc_to_db_dataclass(grpc_dataclass), Dataclass::PROTECTED),
+                _ => assert_eq!(grpc_to_db_dataclass(grpc_dataclass), Dataclass::PRIVATE),
+            }
+        }
+    }
+
+    #[test]
+    fn test_db_to_grpc_dataclass() {
+        for db_dataclass in vec![
+            Dataclass::PUBLIC,
+            Dataclass::PRIVATE,
+            Dataclass::CONFIDENTIAL,
+            Dataclass::PROTECTED,
+        ]
+        .iter()
+        {
+            match db_dataclass {
+                Dataclass::PUBLIC => {
+                    assert_eq!(db_to_grpc_dataclass(db_dataclass), DataClass::Public)
+                }
+                Dataclass::PRIVATE => {
+                    assert_eq!(db_to_grpc_dataclass(db_dataclass), DataClass::Private)
+                }
+                Dataclass::CONFIDENTIAL => {
+                    assert_eq!(db_to_grpc_dataclass(db_dataclass), DataClass::Confidential)
+                }
+                Dataclass::PROTECTED => {
+                    assert_eq!(db_to_grpc_dataclass(db_dataclass), DataClass::Protected)
+                }
+            }
+        }
     }
 
     /// Helper method to return the fully qualified type name of an object

--- a/src/database/models/views.rs
+++ b/src/database/models/views.rs
@@ -1,4 +1,5 @@
 use crate::database::schema::*;
+use bigdecimal::BigDecimal;
 use uuid;
 
 #[derive(Queryable, Identifiable, Debug, Clone)]
@@ -7,7 +8,7 @@ pub struct CollectionStat {
     pub id: uuid::Uuid,
     pub object_count: i64,
     pub object_group_count: i64,
-    pub size: i64,
+    pub size: BigDecimal,
     pub last_updated: chrono::NaiveDateTime,
 }
 
@@ -16,6 +17,6 @@ pub struct CollectionStat {
 pub struct ObjectGroupStat {
     pub id: uuid::Uuid,
     pub object_count: i64,
-    pub size: i64,
+    pub size: BigDecimal,
     pub last_updated: chrono::NaiveDateTime,
 }

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -324,7 +324,7 @@ diesel::table! {
         id -> Uuid,
         object_count -> Int8,
         object_group_count -> Int8,
-        size -> Int8,
+        size -> Numeric,
         last_updated -> Timestamp,
     }
 }
@@ -333,7 +333,7 @@ diesel::table! {
     object_group_stats (id) {
         id -> Uuid,
         object_count -> Int8,
-        size -> Int8,
+        size -> Numeric,
         last_updated -> Timestamp,
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -206,6 +206,7 @@ impl Display for ConnectionError {
 pub enum TypeConversionError {
     UUID,
     TONICMETADATATOSTR,
+    BIGDECIMAL,
     JWT,
     STRTOENDPOINTTYPE,
     PARSECONFIG,
@@ -218,6 +219,12 @@ impl Display for TypeConversionError {
             TypeConversionError::UUID => write!(f, "Typeconversion for UUID failed"),
             TypeConversionError::TONICMETADATATOSTR => {
                 write!(f, "Typeconversion for gRPC metadata 'to_str' failed")
+            }
+            TypeConversionError::BIGDECIMAL => {
+                write!(
+                    f,
+                    "Typecoversion from BIGDECIMAL to int failed (possible overflow)"
+                )
             }
             TypeConversionError::JWT => write!(f, "Typeconversion for JWT failed"),
             TypeConversionError::STRTOENDPOINTTYPE => {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -10,6 +10,7 @@ use crate::server::services::internal_authorize::InternalAuthorizeServiceImpl;
 use crate::server::services::internal_notifications::InternalEventServiceImpl;
 use crate::server::services::objectgroup::ObjectGroupServiceImpl;
 use crate::server::services::project::ProjectServiceImpl;
+use crate::server::services::service_account::ServiceAccountServiceImpl;
 use crate::server::services::user::UserServiceImpl;
 use aruna_rust_api::api::internal::v1::internal_authorize_service_server::InternalAuthorizeServiceServer;
 use aruna_rust_api::api::internal::v1::internal_event_service_server::InternalEventServiceServer;
@@ -19,6 +20,7 @@ use aruna_rust_api::api::storage::services::v1::object_group_service_server::Obj
 use aruna_rust_api::api::storage::services::v1::object_service_server::ObjectServiceServer;
 use aruna_rust_api::api::storage::services::v1::project_service_server::ProjectServiceServer;
 use aruna_rust_api::api::storage::services::v1::resource_info_service_server::ResourceInfoServiceServer;
+use aruna_rust_api::api::storage::services::v1::service_account_service_server::ServiceAccountServiceServer;
 use aruna_rust_api::api::storage::services::v1::storage_info_service_server::StorageInfoServiceServer;
 use aruna_rust_api::api::storage::services::v1::user_service_server::UserServiceServer;
 use tonic::transport::Server;
@@ -94,6 +96,9 @@ impl ServiceServer {
 
         let storage_info_service = StorageInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
+        let service_account_service =
+            ServiceAccountServiceImpl::new(db_ref.clone(), authz.clone()).await;
+
         let internal_event_service =
             InternalEventServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
@@ -111,6 +116,7 @@ impl ServiceServer {
             .add_service(ObjectGroupServiceServer::new(object_group_service))
             .add_service(ResourceInfoServiceServer::new(resource_info_service))
             .add_service(StorageInfoServiceServer::new(storage_info_service))
+            .add_service(ServiceAccountServiceServer::new(service_account_service))
             .add_service(InternalEventServiceServer::new(internal_event_service))
             .add_service(InternalAuthorizeServiceServer::new(
                 internal_authorize_service,

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -6,10 +6,12 @@ use crate::database::cron::{Scheduler, Task};
 use crate::server::services::authz::Authz;
 use crate::server::services::endpoint::EndpointServiceImpl;
 use crate::server::services::info::{ResourceInfoServiceImpl, StorageInfoServiceImpl};
+use crate::server::services::internal_authorize::InternalAuthorizeServiceImpl;
 use crate::server::services::internal_notifications::InternalEventServiceImpl;
 use crate::server::services::objectgroup::ObjectGroupServiceImpl;
 use crate::server::services::project::ProjectServiceImpl;
 use crate::server::services::user::UserServiceImpl;
+use aruna_rust_api::api::internal::v1::internal_authorize_service_server::InternalAuthorizeServiceServer;
 use aruna_rust_api::api::internal::v1::internal_event_service_server::InternalEventServiceServer;
 use aruna_rust_api::api::storage::services::v1::collection_service_server::CollectionServiceServer;
 use aruna_rust_api::api::storage::services::v1::endpoint_service_server::EndpointServiceServer;
@@ -95,6 +97,9 @@ impl ServiceServer {
         let internal_event_service =
             InternalEventServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
+        let internal_authorize_service =
+            InternalAuthorizeServiceImpl::new(db_ref.clone(), authz.clone()).await;
+
         log::info!("ArunaServer listening on {}", addr);
 
         Server::builder()
@@ -107,6 +112,9 @@ impl ServiceServer {
             .add_service(ResourceInfoServiceServer::new(resource_info_service))
             .add_service(StorageInfoServiceServer::new(storage_info_service))
             .add_service(InternalEventServiceServer::new(internal_event_service))
+            .add_service(InternalAuthorizeServiceServer::new(
+                internal_authorize_service,
+            ))
             .serve(addr)
             .await
             .unwrap();

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -5,6 +5,7 @@ use crate::database::connection::Database;
 use crate::database::cron::{Scheduler, Task};
 use crate::server::services::authz::Authz;
 use crate::server::services::endpoint::EndpointServiceImpl;
+use crate::server::services::info::{ResourceInfoServiceImpl, StorageInfoServiceImpl};
 use crate::server::services::objectgroup::ObjectGroupServiceImpl;
 use crate::server::services::project::ProjectServiceImpl;
 use crate::server::services::user::UserServiceImpl;
@@ -13,6 +14,8 @@ use aruna_rust_api::api::storage::services::v1::endpoint_service_server::Endpoin
 use aruna_rust_api::api::storage::services::v1::object_group_service_server::ObjectGroupServiceServer;
 use aruna_rust_api::api::storage::services::v1::object_service_server::ObjectServiceServer;
 use aruna_rust_api::api::storage::services::v1::project_service_server::ProjectServiceServer;
+use aruna_rust_api::api::storage::services::v1::resource_info_service_server::ResourceInfoServiceServer;
+use aruna_rust_api::api::storage::services::v1::storage_info_service_server::StorageInfoServiceServer;
 use aruna_rust_api::api::storage::services::v1::user_service_server::UserServiceServer;
 use tonic::transport::Server;
 
@@ -82,6 +85,11 @@ impl ServiceServer {
             ObjectServiceImpl::new(db_ref.clone(), authz.clone(), default_endpoint.clone()).await;
         let object_group_service = ObjectGroupServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
+        let resource_info_service =
+            ResourceInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
+
+        let storage_info_service = StorageInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
+
         log::info!("ArunaServer listening on {}", addr);
 
         Server::builder()
@@ -91,6 +99,8 @@ impl ServiceServer {
             .add_service(CollectionServiceServer::new(collection_service))
             .add_service(ObjectServiceServer::new(object_service))
             .add_service(ObjectGroupServiceServer::new(object_group_service))
+            .add_service(ResourceInfoServiceServer::new(resource_info_service))
+            .add_service(StorageInfoServiceServer::new(storage_info_service))
             .serve(addr)
             .await
             .unwrap();

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -94,7 +94,9 @@ impl ServiceServer {
         let resource_info_service =
             ResourceInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
-        let storage_info_service = StorageInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
+        let storage_info_service =
+            StorageInfoServiceImpl::new(db_ref.clone(), authz.clone(), config.config.loc_version)
+                .await;
 
         let service_account_service =
             ServiceAccountServiceImpl::new(db_ref.clone(), authz.clone()).await;

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -6,9 +6,11 @@ use crate::database::cron::{Scheduler, Task};
 use crate::server::services::authz::Authz;
 use crate::server::services::endpoint::EndpointServiceImpl;
 use crate::server::services::info::{ResourceInfoServiceImpl, StorageInfoServiceImpl};
+use crate::server::services::internal_notifications::InternalEventServiceImpl;
 use crate::server::services::objectgroup::ObjectGroupServiceImpl;
 use crate::server::services::project::ProjectServiceImpl;
 use crate::server::services::user::UserServiceImpl;
+use aruna_rust_api::api::internal::v1::internal_event_service_server::InternalEventServiceServer;
 use aruna_rust_api::api::storage::services::v1::collection_service_server::CollectionServiceServer;
 use aruna_rust_api::api::storage::services::v1::endpoint_service_server::EndpointServiceServer;
 use aruna_rust_api::api::storage::services::v1::object_group_service_server::ObjectGroupServiceServer;
@@ -90,6 +92,9 @@ impl ServiceServer {
 
         let storage_info_service = StorageInfoServiceImpl::new(db_ref.clone(), authz.clone()).await;
 
+        let internal_event_service =
+            InternalEventServiceImpl::new(db_ref.clone(), authz.clone()).await;
+
         log::info!("ArunaServer listening on {}", addr);
 
         Server::builder()
@@ -101,6 +106,7 @@ impl ServiceServer {
             .add_service(ObjectGroupServiceServer::new(object_group_service))
             .add_service(ResourceInfoServiceServer::new(resource_info_service))
             .add_service(StorageInfoServiceServer::new(storage_info_service))
+            .add_service(InternalEventServiceServer::new(internal_event_service))
             .serve(addr)
             .await
             .unwrap();

--- a/src/server/services/collection.rs
+++ b/src/server/services/collection.rs
@@ -318,9 +318,9 @@ impl CollectionService for CollectionServiceImpl {
 
         let user_id = if request.get_ref().force {
             self.authz
-                .project_authorize(
+                .project_authorize_by_collectionid(
                     request.metadata(),
-                    uuid::Uuid::parse_str(&request.get_ref().project_id)
+                    uuid::Uuid::parse_str(&request.get_ref().collection_id)
                         .map_err(|_| ArunaError::TypeConversionError(TypeConversionError::UUID))?,
                     UserRights::ADMIN,
                 )

--- a/src/server/services/info.rs
+++ b/src/server/services/info.rs
@@ -1,0 +1,48 @@
+use super::authz::Authz;
+use crate::database::connection::Database;
+use aruna_rust_api::api::storage::services::v1::{
+    resource_info_service_server::ResourceInfoService,
+    storage_info_service_server::StorageInfoService, GetResourceHierarchyRequest,
+    GetResourceHierarchyResponse, GetStorageStatusRequest, GetStorageStatusResponse,
+    GetStorageVersionRequest, GetStorageVersionResponse,
+};
+use std::sync::Arc;
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(ResourceInfoServiceImpl);
+
+#[tonic::async_trait]
+impl ResourceInfoService for ResourceInfoServiceImpl {
+    async fn get_resource_hierarchy(
+        &self,
+        _request: tonic::Request<GetResourceHierarchyRequest>,
+    ) -> Result<tonic::Response<GetResourceHierarchyResponse>, tonic::Status> {
+        todo!()
+    }
+}
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(StorageInfoServiceImpl);
+
+#[tonic::async_trait]
+impl StorageInfoService for StorageInfoServiceImpl {
+    /// GetStorageVersion
+    ///
+    /// A request to get the current version of the server application
+    /// String representation and https://semver.org/
+    async fn get_storage_version(
+        &self,
+        _request: tonic::Request<GetStorageVersionRequest>,
+    ) -> Result<tonic::Response<GetStorageVersionResponse>, tonic::Status> {
+        todo!()
+    }
+    /// GetStorageStatus
+    ///
+    /// A request to get the current status of the storage components by location(s)
+    async fn get_storage_status(
+        &self,
+        _request: tonic::Request<GetStorageStatusRequest>,
+    ) -> Result<tonic::Response<GetStorageStatusResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/src/server/services/info.rs
+++ b/src/server/services/info.rs
@@ -3,10 +3,11 @@ use crate::config::LocationVersion;
 use crate::database::connection::Database;
 use aruna_rust_api::api::storage::services::v1::{
     resource_info_service_server::ResourceInfoService,
-    storage_info_service_server::StorageInfoService, ComponentVersion as GRPCCVersion,
-    GetResourceHierarchyRequest, GetResourceHierarchyResponse, GetStorageStatusRequest,
-    GetStorageStatusResponse, GetStorageVersionRequest, GetStorageVersionResponse,
-    LocationVersion as GRPCLocationVersion, SemanticVersion,
+    storage_info_service_server::StorageInfoService, ComponentStatus,
+    ComponentVersion as GRPCCVersion, GetResourceHierarchyRequest, GetResourceHierarchyResponse,
+    GetStorageStatusRequest, GetStorageStatusResponse, GetStorageVersionRequest,
+    GetStorageVersionResponse, LocationStatus, LocationVersion as GRPCLocationVersion,
+    SemanticVersion, Status,
 };
 use std::sync::Arc;
 use tonic::Response;
@@ -83,6 +84,14 @@ impl StorageInfoService for StorageInfoServiceImpl {
         &self,
         _request: tonic::Request<GetStorageStatusRequest>,
     ) -> Result<tonic::Response<GetStorageStatusResponse>, tonic::Status> {
-        todo!()
+        Ok(Response::new(GetStorageStatusResponse {
+            component_status: vec![ComponentStatus {
+                component_name: "backend".to_string(),
+                location_status: vec![LocationStatus {
+                    location: self.config.location.to_string(),
+                    status: Status::Available as i32,
+                }],
+            }],
+        }))
     }
 }

--- a/src/server/services/info.rs
+++ b/src/server/services/info.rs
@@ -67,7 +67,7 @@ impl StorageInfoService for StorageInfoServiceImpl {
                                 component.semver.major,
                                 component.semver.minor,
                                 component.semver.patch,
-                                component.semver.labels.to_string()
+                                component.semver.labels
                             ),
                         }),
                     }],

--- a/src/server/services/info.rs
+++ b/src/server/services/info.rs
@@ -15,8 +15,15 @@ crate::impl_grpc_server!(ResourceInfoServiceImpl);
 impl ResourceInfoService for ResourceInfoServiceImpl {
     async fn get_resource_hierarchy(
         &self,
-        _request: tonic::Request<GetResourceHierarchyRequest>,
+        request: tonic::Request<GetResourceHierarchyRequest>,
     ) -> Result<tonic::Response<GetResourceHierarchyResponse>, tonic::Status> {
+        // Validate token ?
+        // This indicates a "valid token"
+        let token_id = self
+            .authz
+            .validate_and_query_token(request.metadata())
+            .await?;
+
         todo!()
     }
 }

--- a/src/server/services/info.rs
+++ b/src/server/services/info.rs
@@ -15,16 +15,19 @@ crate::impl_grpc_server!(ResourceInfoServiceImpl);
 impl ResourceInfoService for ResourceInfoServiceImpl {
     async fn get_resource_hierarchy(
         &self,
-        request: tonic::Request<GetResourceHierarchyRequest>,
+        _request: tonic::Request<GetResourceHierarchyRequest>,
     ) -> Result<tonic::Response<GetResourceHierarchyResponse>, tonic::Status> {
         // Validate token ?
         // This indicates a "valid token"
-        let token_id = self
-            .authz
-            .validate_and_query_token(request.metadata())
-            .await?;
 
-        todo!()
+        return Err(tonic::Status::unimplemented("In development"));
+
+        // let token_id = self
+        //     .authz
+        //     .validate_and_query_token(request.metadata())
+        //     .await?;
+
+        // todo!()
     }
 }
 

--- a/src/server/services/internal_authorize.rs
+++ b/src/server/services/internal_authorize.rs
@@ -1,0 +1,20 @@
+use super::authz::Authz;
+use crate::database::connection::Database;
+use aruna_rust_api::api::internal::v1::{
+    internal_authorize_service_server::InternalAuthorizeService, AuthorizeRequest,
+    AuthorizeResponse,
+};
+use std::sync::Arc;
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(InternalAuthorizeServiceImpl);
+
+#[tonic::async_trait]
+impl InternalAuthorizeService for InternalAuthorizeServiceImpl {
+    async fn authorize(
+        &self,
+        _request: tonic::Request<AuthorizeRequest>,
+    ) -> Result<tonic::Response<AuthorizeResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/src/server/services/internal_notifications.rs
+++ b/src/server/services/internal_notifications.rs
@@ -1,0 +1,40 @@
+use super::authz::Authz;
+use crate::database::connection::Database;
+use aruna_rust_api::api::internal::v1::{
+    internal_event_service_server::InternalEventService, CreateStreamGroupRequest,
+    CreateStreamGroupResponse, DeleteStreamGroupRequest, DeleteStreamGroupResponse,
+    GetSharedRevisionRequest, GetSharedRevisionResponse, GetStreamGroupRequest,
+    GetStreamGroupResponse,
+};
+use std::sync::Arc;
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(InternalEventServiceImpl);
+
+#[tonic::async_trait]
+impl InternalEventService for InternalEventServiceImpl {
+    async fn create_stream_group(
+        &self,
+        _request: tonic::Request<CreateStreamGroupRequest>,
+    ) -> Result<tonic::Response<CreateStreamGroupResponse>, tonic::Status> {
+        todo!()
+    }
+    async fn get_stream_group(
+        &self,
+        _request: tonic::Request<GetStreamGroupRequest>,
+    ) -> Result<tonic::Response<GetStreamGroupResponse>, tonic::Status> {
+        todo!()
+    }
+    async fn delete_stream_group(
+        &self,
+        _request: tonic::Request<DeleteStreamGroupRequest>,
+    ) -> Result<tonic::Response<DeleteStreamGroupResponse>, tonic::Status> {
+        todo!()
+    }
+    async fn get_shared_revision(
+        &self,
+        _request: tonic::Request<GetSharedRevisionRequest>,
+    ) -> Result<tonic::Response<GetSharedRevisionResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod authz;
 pub mod collection;
 pub mod endpoint;
+pub mod info;
 pub mod object;
 pub mod objectgroup;
 pub mod project;

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -7,3 +7,6 @@ pub mod objectgroup;
 pub mod project;
 pub mod user;
 pub mod utils;
+// ----- INTERNAL Services -----
+
+pub mod internal_notifications;

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -9,4 +9,5 @@ pub mod user;
 pub mod utils;
 // ----- INTERNAL Services -----
 
+pub mod internal_authorize;
 pub mod internal_notifications;

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -5,6 +5,7 @@ pub mod info;
 pub mod object;
 pub mod objectgroup;
 pub mod project;
+pub mod service_account;
 pub mod user;
 pub mod utils;
 // ----- INTERNAL Services -----

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -955,10 +955,10 @@ impl ObjectService for ObjectServiceImpl {
         return Ok(response);
     }
 
-    async fn add_label_to_object(
+    async fn add_labels_to_object(
         &self,
-        request: Request<AddLabelToObjectRequest>,
-    ) -> Result<Response<AddLabelToObjectResponse>, Status> {
+        request: Request<AddLabelsToObjectRequest>,
+    ) -> Result<Response<AddLabelsToObjectResponse>, Status> {
         log::info!("Received AddLabelToObjectRequest.");
         log::debug!("{}", format_grpc_request(&request));
 
@@ -975,7 +975,7 @@ impl ObjectService for ObjectServiceImpl {
         // Create Object in database
         let database_clone = self.database.clone();
         let response = Response::new(
-            task::spawn_blocking(move || database_clone.add_label_to_object(request.into_inner()))
+            task::spawn_blocking(move || database_clone.add_labels_to_object(request.into_inner()))
                 .await
                 .map_err(ArunaError::from)??,
         );

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -266,7 +266,7 @@ impl ObjectService for ObjectServiceImpl {
         let upload_url = data_proxy
             .create_presigned_upload_url(CreatePresignedUploadUrlRequest {
                 multipart: inner_request.multipart,
-                part_number: part_number,
+                part_number,
                 location: Some(location),
                 upload_id: inner_request.upload_id, //Note: Can be moved, only used here
             })

--- a/src/server/services/service_account.rs
+++ b/src/server/services/service_account.rs
@@ -1,0 +1,110 @@
+use aruna_rust_api::api::storage::services::v1::{
+    service_account_service_server::ServiceAccountService, CreateServiceAccountRequest,
+    CreateServiceAccountResponse, CreateServiceAccountTokenRequest,
+    CreateServiceAccountTokenResponse, DeleteServiceAccountRequest, DeleteServiceAccountResponse,
+    DeleteServiceAccountTokenRequest, DeleteServiceAccountTokenResponse,
+    DeleteServiceAccountTokensRequest, DeleteServiceAccountTokensResponse,
+    EditServiceAccountPermissionRequest, EditServiceAccountPermissionResponse,
+    GetServiceAccountTokenRequest, GetServiceAccountTokenResponse, GetServiceAccountTokensRequest,
+    GetServiceAccountTokensResponse, GetServiceAccountsByProjectRequest,
+    GetServiceAccountsByProjectResponse,
+};
+
+use super::authz::Authz;
+use crate::database::connection::Database;
+use std::sync::Arc;
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(ServiceAccountServiceImpl);
+
+#[tonic::async_trait]
+impl ServiceAccountService for ServiceAccountServiceImpl {
+    /// CreateServiceAccount
+    ///
+    /// Creates a service account for a given project
+    /// If the service account has permissions for the global Admin project
+    /// it will be a global service account that can interact with any resource
+    async fn create_service_account(
+        &self,
+        _request: tonic::Request<CreateServiceAccountRequest>,
+    ) -> Result<tonic::Response<CreateServiceAccountResponse>, tonic::Status> {
+        todo!()
+    }
+    /// CreateServiceAccountToken
+    ///
+    /// Creates a token for a service account
+    /// Each service account can only have one permission -> The token will have the same permission as the
+    /// service account
+    async fn create_service_account_token(
+        &self,
+        _request: tonic::Request<CreateServiceAccountTokenRequest>,
+    ) -> Result<tonic::Response<CreateServiceAccountTokenResponse>, tonic::Status> {
+        todo!()
+    }
+    /// EditServiceAccountPermission
+    ///
+    /// Overwrites the project specific permissions for a service account
+    async fn edit_service_account_permission(
+        &self,
+        _request: tonic::Request<EditServiceAccountPermissionRequest>,
+    ) -> Result<tonic::Response<EditServiceAccountPermissionResponse>, tonic::Status> {
+        todo!()
+    }
+    /// GetServiceAccountToken
+    ///
+    /// This requests the overall information about a specifc service account token (by id)
+    /// it will not contain the token itself.
+    async fn get_service_account_token(
+        &self,
+        _request: tonic::Request<GetServiceAccountTokenRequest>,
+    ) -> Result<tonic::Response<GetServiceAccountTokenResponse>, tonic::Status> {
+        todo!()
+    }
+    /// GetServiceAccountTokens
+    ///
+    /// This requests the overall information about all service account tokens
+    /// it will not contain the token itself.
+    async fn get_service_account_tokens(
+        &self,
+        _request: tonic::Request<GetServiceAccountTokensRequest>,
+    ) -> Result<tonic::Response<GetServiceAccountTokensResponse>, tonic::Status> {
+        todo!()
+    }
+    /// GetServiceAccountsByProject
+    ///
+    /// Will request all service_accounts for a given project
+    /// each service account is bound to a specific project
+    async fn get_service_accounts_by_project(
+        &self,
+        _request: tonic::Request<GetServiceAccountsByProjectRequest>,
+    ) -> Result<tonic::Response<GetServiceAccountsByProjectResponse>, tonic::Status> {
+        todo!()
+    }
+    /// DeleteServiceAccountToken
+    ///
+    /// Deletes one service account token by ID
+    async fn delete_service_account_token(
+        &self,
+        _request: tonic::Request<DeleteServiceAccountTokenRequest>,
+    ) -> Result<tonic::Response<DeleteServiceAccountTokenResponse>, tonic::Status> {
+        todo!()
+    }
+    /// DeleteServiceAccountTokens
+    ///
+    /// Deletes all service account tokens
+    async fn delete_service_account_tokens(
+        &self,
+        _request: tonic::Request<DeleteServiceAccountTokensRequest>,
+    ) -> Result<tonic::Response<DeleteServiceAccountTokensResponse>, tonic::Status> {
+        todo!()
+    }
+    /// DeleteServiceAccount
+    ///
+    /// Deletes a service account (by id)
+    async fn delete_service_account(
+        &self,
+        _request: tonic::Request<DeleteServiceAccountRequest>,
+    ) -> Result<tonic::Response<DeleteServiceAccountResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/tests/b1_authz_test.rs
+++ b/tests/b1_authz_test.rs
@@ -635,6 +635,7 @@ fn get_user_projects_test() {
             user_id: user_id.to_string(),
             project_id: proj_1.clone().project_id,
             permission: 2,
+            service_account: false,
         }),
     };
     db.add_user_to_project(add_user_req, user_id).unwrap();
@@ -704,6 +705,7 @@ fn get_checked_user_id_from_token_test() {
             user_id: user_id.to_string(),
             project_id: proj_1.clone().project_id,
             permission: 2,
+            service_account: false,
         }),
     };
     db.add_user_to_project(add_user_req, user_id).unwrap();

--- a/tests/b2_authz_user_grpc_test.rs
+++ b/tests/b2_authz_user_grpc_test.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aruna_rust_api::api::storage::services::v1::{
     user_service_server::UserService, ActivateUserRequest, CreateApiTokenRequest,
-    GetApiTokenRequest, RegisterUserRequest,
+    GetApiTokenRequest, GetUserRequest, RegisterUserRequest,
 };
 use aruna_server::{
     database::{self},
@@ -282,6 +282,15 @@ async fn get_api_token_grpc_test() {
     ));
     let authz = Arc::new(Authz::new(db.clone()).await);
     let userservice = UserServiceImpl::new(db, authz).await;
+
+    // Get User
+    let get_req = common::grpc_helpers::add_token(
+        tonic::Request::new(GetUserRequest {
+            user_id: "".to_string(),
+        }),
+        common::oidc::REGULAROIDC,
+    );
+    let _resp = userservice.get_user(get_req).await.unwrap();
 
     // First Create a token
     let req = common::grpc_helpers::add_token(

--- a/tests/c_project_tests.rs
+++ b/tests/c_project_tests.rs
@@ -181,6 +181,7 @@ fn add_remove_project_user_test() {
                 user_id: user_id.to_string(),
                 project_id: project_id.to_string(),
                 permission: rng.gen_range(2..5),
+                service_account: false,
             }),
         };
 
@@ -258,6 +259,7 @@ fn edit_project_user_permissions_test() {
         user_id: user_id.to_string(),
         project_id: project_id.to_string(),
         permission: 5,
+        service_account: false,
     };
     let user_add_request = AddUserToProjectRequest {
         project_id: project_id.to_string(),
@@ -278,6 +280,7 @@ fn edit_project_user_permissions_test() {
         user_id: user_id.to_string(),
         project_id: project_id.to_string(),
         permission: 2,
+        service_account: false,
     };
     let edit_permission_request = EditUserPermissionsForProjectRequest {
         project_id: project_id.to_string(),

--- a/tests/common/functions.rs
+++ b/tests/common/functions.rs
@@ -457,6 +457,7 @@ pub fn update_object(update: &TCreateUpdate) -> Object {
             labels: dummy_labels.clone(),
             hooks: dummy_hooks.clone(),
         }),
+        force: true,
         reupload: true,
         preferred_endpoint_id: "".to_string(),
         multi_part: false,

--- a/tests/d_collection_tests.rs
+++ b/tests/d_collection_tests.rs
@@ -537,7 +537,6 @@ fn update_collection_test() {
     let _obj_grp_res = db.create_object_group(&obj_grp, &creator).unwrap();
 
     let normal_update = UpdateCollectionRequest {
-        project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         collection_id: col_id.to_string(),
         name: "new_name".to_string(),
         description: "new_descrpt".to_string(),
@@ -559,7 +558,6 @@ fn update_collection_test() {
     assert_eq!(up_res.collection.unwrap().id, col_id.to_string());
 
     let pin_update = UpdateCollectionRequest {
-        project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         collection_id: col_id.to_string(),
         name: "new_name".to_string(),
         description: "new_descrpt".to_string(),
@@ -587,7 +585,6 @@ fn update_collection_test() {
     assert!(pin_up_res.is_err());
 
     let pin_update = UpdateCollectionRequest {
-        project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         collection_id: col_id.to_string(),
         name: "new_name".to_string(),
         description: "new_descrpt".to_string(),
@@ -938,7 +935,6 @@ fn delete_collection_test() {
 
     let delete_req_normal = DeleteCollectionRequest {
         collection_id: col_id.to_string(),
-        project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         force: false,
     };
 
@@ -948,7 +944,6 @@ fn delete_collection_test() {
 
     let delete_req_force = DeleteCollectionRequest {
         collection_id: col_id.to_string(),
-        project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         force: true,
     };
 

--- a/tests/d_collection_tests.rs
+++ b/tests/d_collection_tests.rs
@@ -1057,7 +1057,7 @@ pub fn test_collection_materialized_views_stats() {
         object_id: new_object_id.to_string(),
         upload_id,
         collection_id: collection_id.to_string(),
-        hash: Some(finish_hash.clone()),
+        hash: Some(finish_hash),
         no_upload: false,
         completed_parts: vec![],
         auto_update: true,

--- a/tests/d_collection_tests.rs
+++ b/tests/d_collection_tests.rs
@@ -1,7 +1,8 @@
 mod common;
 use aruna_rust_api::api::internal::v1::Location;
 use aruna_rust_api::api::storage::models::v1::{
-    collection_overview, KeyValue, LabelFilter, LabelOntology, LabelOrIdQuery, PageRequest, Version,
+    collection_overview, DataClass, EndpointType, Hashalgorithm, KeyValue, LabelFilter,
+    LabelOntology, LabelOrIdQuery, PageRequest, Version,
 };
 use aruna_rust_api::api::storage::services::v1::*;
 use aruna_server::database;
@@ -960,4 +961,131 @@ pub fn test_materialized_view_refreshs() {
     assert!(result.is_ok());
     let result = db.update_object_group_views();
     assert!(result.is_ok());
+}
+
+#[test]
+#[ignore]
+#[serial(db)]
+pub fn test_collection_materialized_views_stats() {
+    let db = database::connection::Database::new("postgres://root:test123@localhost:26257/test");
+    let creator = uuid::Uuid::parse_str("12345678-1234-1234-1234-111111111111").unwrap();
+    let endpoint_id = uuid::Uuid::parse_str("12345678-6666-6666-6666-999999999999").unwrap();
+
+    // Create fresh Project
+    let create_project_request = CreateProjectRequest {
+        name: "Object creation test project".to_string(),
+        description: "Test project used in object creation test.".to_string(),
+    };
+
+    let create_project_response = db.create_project(create_project_request, creator).unwrap();
+    let project_id = uuid::Uuid::parse_str(&create_project_response.project_id).unwrap();
+
+    assert!(!project_id.is_nil());
+
+    // Create Collection
+    let create_collection_request = CreateNewCollectionRequest {
+        name: "Object creation test project collection".to_string(),
+        description: "Test collection used in object creation test.".to_string(),
+        label_ontology: None,
+        project_id: project_id.to_string(),
+        labels: vec![],
+        hooks: vec![],
+        dataclass: DataClass::Private as i32,
+    };
+    let create_collection_response = db
+        .create_new_collection(create_collection_request, creator)
+        .unwrap();
+    let collection_id = uuid::Uuid::parse_str(&create_collection_response.collection_id).unwrap();
+
+    // Create Object
+    let new_object_id = uuid::Uuid::new_v4();
+    let upload_id = uuid::Uuid::new_v4().to_string();
+
+    let location = Location {
+        r#type: EndpointType::S3 as i32,
+        bucket: collection_id.to_string(),
+        path: new_object_id.to_string(),
+    };
+
+    let init_object_request = InitializeNewObjectRequest {
+        object: Some(StageObject {
+            filename: "File.file".to_string(),
+            description: "This is a mock file.".to_string(),
+            collection_id: collection_id.to_string(),
+            content_len: 1337,
+            source: None,
+            dataclass: DataClass::Private as i32,
+            labels: vec![KeyValue {
+                key: "LabelKey".to_string(),
+                value: "LabelValue".to_string(),
+            }],
+            hooks: vec![KeyValue {
+                key: "HookKey".to_string(),
+                value: "HookValue".to_string(),
+            }],
+        }),
+        collection_id: collection_id.to_string(),
+        preferred_endpoint_id: endpoint_id.to_string(),
+        multipart: false,
+        is_specification: false,
+    };
+
+    let init_object_response = db
+        .create_object(
+            &init_object_request,
+            &creator,
+            &location,
+            upload_id.clone(),
+            endpoint_id,
+            new_object_id,
+        )
+        .unwrap();
+
+    assert_eq!(&init_object_response.object_id, &new_object_id.to_string());
+    assert_eq!(
+        &init_object_response.collection_id,
+        &collection_id.to_string()
+    );
+    assert_eq!(&init_object_response.upload_id, &upload_id);
+
+    // Finish object staging
+    let finish_hash = aruna_rust_api::api::storage::models::v1::Hash {
+        alg: Hashalgorithm::Sha256 as i32,
+        hash: "f60b102aa455f085df91ffff53b3c0acd45c10f02782b953759ab10973707a92".to_string(),
+    };
+    let finish_request = FinishObjectStagingRequest {
+        object_id: new_object_id.to_string(),
+        upload_id,
+        collection_id: collection_id.to_string(),
+        hash: Some(finish_hash.clone()),
+        no_upload: false,
+        completed_parts: vec![],
+        auto_update: true,
+    };
+
+    let _finish_response = db.finish_object_staging(&finish_request, &creator).unwrap();
+
+    // Objects initialized -> refresh views
+
+    let result = db.update_collection_views();
+    assert!(result.is_ok());
+
+    // Get collection by ID
+    let q_col_req = GetCollectionByIdRequest {
+        collection_id: collection_id.to_string(),
+    };
+    let queried_col = db.get_collection_by_id(q_col_req).unwrap();
+
+    // Acc size should be 1337
+    assert_eq!(
+        queried_col
+            .collection
+            .unwrap()
+            .stats
+            .unwrap()
+            .object_stats
+            .unwrap()
+            .acc_size,
+        1337
+    )
 }

--- a/tests/e_object_tests.rs
+++ b/tests/e_object_tests.rs
@@ -605,6 +605,7 @@ fn delete_object_test() {
             labels: Vec::new(),
             hooks: Vec::new(),
         }),
+        force: true,
         reupload: false,
         is_specification: false,
         preferred_endpoint_id: "".to_string(),

--- a/tests/e_object_tests.rs
+++ b/tests/e_object_tests.rs
@@ -48,7 +48,7 @@ fn create_object_test() {
         project_id: project_id.to_string(),
         labels: vec![],
         hooks: vec![],
-        dataclass: 1,
+        dataclass: DataClass::Private as i32,
     };
     let create_collection_response = db
         .create_new_collection(create_collection_request, creator)
@@ -72,7 +72,7 @@ fn create_object_test() {
             collection_id: collection_id.to_string(),
             content_len: 1234,
             source: None,
-            dataclass: 1,
+            dataclass: DataClass::Private as i32,
             labels: vec![KeyValue {
                 key: "LabelKey".to_string(),
                 value: "LabelValue".to_string(),
@@ -123,12 +123,12 @@ fn create_object_test() {
 
     let finish_response = db.finish_object_staging(&finish_request, &creator).unwrap();
     let finished_object = finish_response.object.unwrap();
-
     assert_eq!(finished_object.id, new_object_id.to_string());
     assert!(matches!(
         grpc_to_db_object_status(&finished_object.status),
         ObjectStatus::AVAILABLE
     ));
+    assert_eq!(finished_object.data_class, DataClass::Private as i32);
     assert_eq!(finished_object.rev_number, 0);
     assert_eq!(finished_object.filename, "File.file".to_string());
     assert_eq!(finished_object.content_len, 1234);

--- a/tests/i_info_grpc.rs
+++ b/tests/i_info_grpc.rs
@@ -59,8 +59,7 @@ async fn storage_info_version_test() {
         .into_inner();
 
     assert_eq!(
-        resp.clone()
-            .component_version
+        resp.component_version
             .first()
             .unwrap()
             .location_version

--- a/tests/i_info_grpc.rs
+++ b/tests/i_info_grpc.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use aruna_rust_api::api::storage::services::v1::{
+    storage_info_service_server::StorageInfoService, GetStorageStatusRequest,
+    GetStorageVersionRequest,
+};
+use aruna_server::{
+    config::ArunaServerConfig,
+    database::{self},
+    server::services::{authz::Authz, info::StorageInfoServiceImpl},
+};
+use serial_test::serial;
+mod common;
+
+#[ignore]
+#[tokio::test]
+#[serial(db)]
+async fn storage_info_status_test() {
+    // Init services
+    let db = Arc::new(database::connection::Database::new(
+        "postgres://root:test123@localhost:26257/test",
+    ));
+
+    let authz = Arc::new(Authz::new(db.clone()).await);
+    let config = ArunaServerConfig::new();
+    let infoservice = StorageInfoServiceImpl::new(db, authz, config.config.loc_version).await;
+
+    let req = tonic::Request::new(GetStorageStatusRequest {});
+    let resp = infoservice
+        .get_storage_status(req)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.component_status.first().unwrap().component_name,
+        "backend".to_string()
+    )
+}
+
+#[ignore]
+#[tokio::test]
+#[serial(db)]
+async fn storage_info_version_test() {
+    // Init services
+    let db = Arc::new(database::connection::Database::new(
+        "postgres://root:test123@localhost:26257/test",
+    ));
+
+    let authz = Arc::new(Authz::new(db.clone()).await);
+    let config = ArunaServerConfig::new();
+    let infoservice = StorageInfoServiceImpl::new(db, authz, config.config.loc_version).await;
+
+    let req = tonic::Request::new(GetStorageVersionRequest {});
+    let resp = infoservice
+        .get_storage_version(req)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.clone()
+            .component_version
+            .first()
+            .unwrap()
+            .location_version
+            .first()
+            .unwrap()
+            .location,
+        "FOO".to_string()
+    );
+
+    assert_eq!(
+        resp.component_version
+            .first()
+            .unwrap()
+            .location_version
+            .first()
+            .unwrap()
+            .version
+            .as_ref()
+            .unwrap()
+            .minor,
+        1
+    )
+}


### PR DESCRIPTION
# Overview

PR that accumulates various changes from 0.5.0 and previous beta development to the dev branch.
The changes include:

### Changelog (Overview)

- Updated API to 0.5.0
- AddLabelsToObjectGroup request (inline with similar Object request)
- Limits update functionality without force to only the most recent object to prevent concurrency issues
- First iteration of an info service that provides status and version information for registered components
- Various added tests for info service
- Stubs for the notification service (currently unavailable)
- Stubs for the service account service (currently unavailable)

A more sophisticated changelog is provided via the commitlog.

This is the first stable release for 0.5.0, please report any issues that occur with this release.

