### PR TITLE
Add additional tests for gRPC service functions

### DIFF
--- a/migrations/2023-02-03-103413_parallel_collection_object/down.sql
+++ b/migrations/2023-02-03-103413_parallel_collection_object/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE collection_objects ADD CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id);
+DROP INDEX parallel_collection_object CASCADE;

--- a/migrations/2023-02-03-103413_parallel_collection_object/up.sql
+++ b/migrations/2023-02-03-103413_parallel_collection_object/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE collection_objects ADD CONSTRAINT parallel_collection_object UNIQUE (object_id, collection_id, auto_update);
+DROP INDEX unique_collection_object CASCADE;

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -11,7 +11,7 @@
 use super::utils::*;
 use crate::database;
 use crate::database::connection::Database;
-use crate::database::crud::object::{clone_object, delete_multiple_objects};
+use crate::database::crud::object::{clone_object, safe_delete_object};
 use crate::database::models;
 use crate::database::models::collection::{
     Collection, CollectionKeyValue, CollectionObject, CollectionObjectGroup, CollectionVersion,
@@ -635,7 +635,17 @@ impl Database {
             .map(|elem| elem.object_id)
             .collect::<Vec<_>>();
             if !all_obj_ids.is_empty() {
-                delete_multiple_objects(all_obj_ids, collection_id, true, false, user_id, conn)?;
+                //delete_multiple_objects(all_obj_ids, collection_id, true, false, user_id, conn)?;
+                for object_uuid in all_obj_ids {
+                    safe_delete_object(
+                        &object_uuid,
+                    &collection_id,
+                    true,
+                    false,
+                        user_id,
+                        conn
+                    )?;
+                }
             }
             // Delete all collection_key_values
             delete(

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -9,6 +9,7 @@
 //! - PinCollectionVersion
 //! - DeleteCollection
 use super::utils::*;
+use crate::database;
 use crate::database::connection::Database;
 use crate::database::crud::object::{clone_object, delete_multiple_objects};
 use crate::database::models;
@@ -20,6 +21,7 @@ use crate::database::models::enums::{Dataclass as DBDataclass, KeyValueType, Ref
 use crate::database::models::object::{Object, ObjectKeyValue};
 use crate::database::models::object_group::{ObjectGroup, ObjectGroupKeyValue, ObjectGroupObject};
 use crate::database::models::views::CollectionStat;
+use crate::database::schema::collections::dsl::collections;
 use crate::error::{ArunaError, TypeConversionError};
 use aruna_rust_api::api::storage::models::v1::DataClass;
 use aruna_rust_api::api::storage::models::v1::{
@@ -648,6 +650,34 @@ impl Database {
 }
 
 /* ----------------- Section for collection specific helper functions ------------------- */
+
+/// This is a helper function that checks if a collection is pinned to a version.
+///
+/// ## Arguments
+///
+/// *  conn: &mut PooledConnection<ConnectionManager<PgConnection>>, Database connection
+/// *  collection_uuid: Unique collection id
+///
+/// ## Returns
+///
+/// * Result<bool, ArunaError>: Returns true if collection has a version; false else.
+///
+pub fn is_collection_versioned(
+    conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
+    collection_uuid: &uuid::Uuid,
+) -> Result<bool, ArunaError> {
+    // Get collection version from database
+    let collection_version: Option<uuid::Uuid> = collections
+        .filter(database::schema::collections::id.eq(collection_uuid))
+        .select(database::schema::collections::version_id)
+        .first::<Option<uuid::Uuid>>(conn)?;
+
+    // Unwrap Option with version id
+    match collection_version {
+        None => Ok(false),
+        Some(_) => Ok(true),
+    }
+}
 
 /// This is a helper function that queries and builds a CollectionOverviewDb based on an existing collection query
 /// Used to query all associated Tables and map them to one consistent struct.

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -47,7 +47,7 @@ use crate::database::models::enums::{
 use crate::database::models::object::{
     Endpoint, Hash as ApiHash, Object, ObjectKeyValue, ObjectLocation, Source,
 };
-use crate::database::schema::collections::dsl::collections;
+
 use crate::database::schema::{
     collection_object_groups::dsl::*, collection_objects::dsl::*, endpoints::dsl::*,
     hashes::dsl::*, object_group_objects::dsl::*, object_key_value::dsl::*,

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -637,7 +637,7 @@ impl ObjectService for ObjectServiceImpl {
                 .project_authorize_by_collectionid(
                     request.metadata(),
                     target_collection_uuid, // This is the collection uuid which the project_id will be based
-                    UserRights::ADMIN, // User needs at least append permission to create an object
+                    UserRights::ADMIN, // User needs at least admin permission to force delete an object
                 )
                 .await?
         } else {
@@ -648,7 +648,7 @@ impl ObjectService for ObjectServiceImpl {
                 .collection_authorize(
                     request.metadata(),
                     target_collection_uuid, // This is the collection uuid in which this object should be created
-                    UserRights::APPEND, // User needs at least append permission to create an object
+                    UserRights::APPEND, // User needs at least append permission to delete an object
                 )
                 .await?
         };

--- a/tests/common/functions.rs
+++ b/tests/common/functions.rs
@@ -237,7 +237,10 @@ pub fn create_collection(tccol: TCreateCollection) -> CollectionOverview {
     // Collection should have the following name
     assert_eq!(get_col_resp.name, create_collection_request_test.name);
     // Collection should not have a version
-    assert_eq!(get_col_resp.version.clone().unwrap(), collection_overview::Version::Latest(true));
+    assert_eq!(
+        get_col_resp.version.clone().unwrap(),
+        collection_overview::Version::Latest(true)
+    );
     assert!(
         // Should be empty vec
         get_col_resp

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -1093,7 +1093,6 @@ fn delete_multiple_objects_test() {
     assert_eq!(resp.len(), 2); // obj_1_rev_0 read-only reference and obj_3_rev_0 is moved here
 }
 
-
 #[test]
 #[ignore]
 #[serial(db)]

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -1027,7 +1027,7 @@ fn delete_multiple_objects_test() {
     // Test deletes
     let ids = vec![
         rnd_obj_1_rev_1.id,
-        rnd_obj_2_rev_0.clone().id,
+        rnd_obj_2_rev_0.id,
         rnd_obj_3_rev_0.id,
     ];
 
@@ -1106,7 +1106,7 @@ fn delete_object_from_versioned_collection_test() {
 
     // Create random collection
     let random_collection = create_collection(TCreateCollection {
-        project_id: random_project.id.to_string(),
+        project_id: random_project.id,
         col_override: None,
         ..Default::default()
     });
@@ -1124,7 +1124,7 @@ fn delete_object_from_versioned_collection_test() {
 
     // Pin collection to version
     let pin_request = PinCollectionVersionRequest {
-        collection_id: random_collection.id.to_string(),
+        collection_id: random_collection.id,
         version: Some(Version {
             major: 1,
             minor: 0,
@@ -1146,12 +1146,12 @@ fn delete_object_from_versioned_collection_test() {
     };
     let collection_objects = db.get_objects(get_request).unwrap().unwrap();
 
-    assert!(collection_objects.len() > 0);
+    assert!(!collection_objects.is_empty());
 
     // Try to delete objects from versioned collection
     let delete_request = DeleteObjectRequest {
         object_id: collection_objects.first().unwrap().object.id.to_string(),
-        collection_id: versioned_collection.id.to_string(),
+        collection_id: versioned_collection.id,
         with_revisions: false,
         force: true,
     };

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -1025,11 +1025,7 @@ fn delete_multiple_objects_test() {
     let _resp = db.create_object_reference(create_ref).unwrap();
 
     // Test deletes
-    let ids = vec![
-        rnd_obj_1_rev_1.id,
-        rnd_obj_2_rev_0.id,
-        rnd_obj_3_rev_0.id,
-    ];
+    let ids = vec![rnd_obj_1_rev_1.id, rnd_obj_2_rev_0.id, rnd_obj_3_rev_0.id];
 
     let del_req = DeleteObjectsRequest {
         object_ids: ids.clone(),

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -2476,17 +2476,18 @@ async fn delete_object_grpc_test() {
                     }),
                     common::oidc::ADMINTOKEN,
                 );
-                let all_references = object_service
-                    .get_references(all_references_request)
-                    .await
-                    .unwrap()
-                    .into_inner()
-                    .references
-                    .into_iter()
-                    .filter(|reference| reference.is_writeable)
-                    .collect::<Vec<_>>();
-
-                assert_ne!(all_references.len(), 0); // At least one writeable reference exist. Could also be less than 0 but that is very improbable...
+                assert_ne!(
+                    object_service
+                        .get_references(all_references_request)
+                        .await
+                        .unwrap()
+                        .into_inner()
+                        .references
+                        .into_iter()
+                        .filter(|reference| reference.is_writeable)
+                        .count(),
+                    0
+                ); // At least one writeable reference exist. Could also be less than 0 but that is very improbable...
             }
             _ => panic!("Unspecified permission is not allowed."),
         }
@@ -2906,7 +2907,7 @@ async fn delete_object_revisions_grpc_test() {
 
     let mut update_meta = TCreateUpdate {
         original_object: random_object.clone(),
-        collection_id: random_collection.id.to_string().to_string(),
+        collection_id: random_collection.id.to_string(),
         new_name: "random_update.01".to_string(),
         new_description: "".to_string(), // No use.
         content_len: 123,
@@ -3305,7 +3306,7 @@ async fn delete_multiple_objects_grpc_test() {
 
     let mut update_meta = TCreateUpdate {
         original_object: random_object.clone(),
-        collection_id: random_collection.id.to_string().to_string(),
+        collection_id: random_collection.id.to_string(),
         new_name: "random_update.01".to_string(),
         new_description: "".to_string(), // No use.
         content_len: 123,

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -2667,7 +2667,9 @@ async fn delete_object_grpc_test() {
         }),
         common::oidc::REGULARTOKEN,
     );
-    let get_deleted_object_response = object_service.get_object_by_id(get_deleted_object_request).await;
+    let get_deleted_object_response = object_service
+        .get_object_by_id(get_deleted_object_request)
+        .await;
 
     assert!(get_deleted_object_response.is_err());
 
@@ -2751,7 +2753,7 @@ async fn delete_object_grpc_test() {
     });
 
     assert_ne!(updated_object.id, staging_object_id);
-    assert_eq!(updated_object.rev_number, 1); 
+    assert_eq!(updated_object.rev_number, 1);
 }
 
 /// The individual steps of this test function contains:
@@ -3022,7 +3024,7 @@ async fn delete_multiple_objects_grpc_test() {
         user_id.as_str(),
         common::oidc::ADMINTOKEN,
     )
-        .await;
+    .await;
     assert_eq!(add_perm.permission, Permission::None as i32);
 
     // Fast track collection creation
@@ -3043,7 +3045,7 @@ async fn delete_multiple_objects_grpc_test() {
         Permission::Modify,
         Permission::Admin,
     ]
-        .iter()
+    .iter()
     {
         // Fast track permission edit
         let edit_perm = common::grpc_helpers::edit_project_permission(
@@ -3052,7 +3054,7 @@ async fn delete_multiple_objects_grpc_test() {
             permission,
             common::oidc::ADMINTOKEN,
         )
-            .await;
+        .await;
         assert_eq!(edit_perm.permission, *permission as i32);
 
         // Create objects
@@ -3066,7 +3068,7 @@ async fn delete_multiple_objects_grpc_test() {
                     num_labels: 0,
                     num_hooks: 0,
                 })
-                    .id,
+                .id,
             );
         }
 
@@ -3164,7 +3166,7 @@ async fn delete_multiple_objects_grpc_test() {
         Permission::Modify,
         Permission::Admin,
     ]
-        .iter()
+    .iter()
     {
         // Fast track permission edit
         let edit_perm = common::grpc_helpers::edit_project_permission(
@@ -3173,7 +3175,7 @@ async fn delete_multiple_objects_grpc_test() {
             permission,
             common::oidc::ADMINTOKEN,
         )
-            .await;
+        .await;
         assert_eq!(edit_perm.permission, *permission as i32);
 
         // Create multiple objects

--- a/tests/sources/up.sql
+++ b/tests/sources/up.sql
@@ -227,7 +227,8 @@ CREATE TABLE collection_objects (
     reference_status REFERENCE_STATUS NOT NULL DEFAULT 'OK',
     FOREIGN KEY (object_id) REFERENCES objects(id),
     FOREIGN KEY (collection_id) REFERENCES collections(id),
-    CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id)
+    -- Unique reference possible for static and auto_update parallel on same revision
+    CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id, auto_update)
 );
 -- Join table between collections and object_groups
 CREATE TABLE collection_object_groups (


### PR DESCRIPTION
This extends the test coverage over the gRPC Service functions including some edge cases that may occur in day to day usage of the AOS. This PR additionally deals with inconsistencies that may occur due to the previous implementation of the functionality to delete objects. Details about the bugs that have been fixed can be found under _Changes_  using the linked issues.

## Tests added

* Object CRUD test for object deletion from versioned collections
* gRPC ObjectService - Individual object deletion with/without revisions
* gRPC ObjectService - Multiple object deletion with/without revisions

## Changes

* Objects can no longer be deleted from versioned collections (Fixes #59)
* Outdated revisions can be deleted under specific circumstances (Fixes #60)
* Dangling objects without a writable reference in at least one collection should now not be able to result from deletion (Fixes #61)