### PR TITLE
Update Server to ArunaAPI 1.0.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "aruna-rust-api"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ceb05370086253f95cfdacbf87711625208bd833d4673a2a69d63679a56401"
+checksum = "65f0794ae9e19a2c9443b7bddd0a7002ee0e1496e5da280042e0723aa977f052"
 dependencies = [
  "prost",
  "prost-types",
@@ -77,19 +77,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -126,9 +127,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -283,9 +284,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cxx"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -295,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -310,15 +311,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -360,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "diesel-derive-enum"
-version = "2.0.0-rc.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f28fc9f5bf184ebc58ad9105dede024981e2303fe878a0fe16557f3a979064a"
+checksum = "6b10c03b954333d05bfd5be1d8a74eae2c9ca77b86e0f1c3a1ea29c49da1d6c2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -405,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -587,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -831,14 +832,14 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -863,15 +864,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -925,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -1120,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "3933d3ac2717077b3d5f42b40f59edfb1fb6a8c14e1c7de0f38075c4bac8e314"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1130,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
+checksum = "a24be1d23b4552a012093e1b93697b73d644ae9590e3253d878d0e77d411b614"
 dependencies = [
  "bytes",
  "heck",
@@ -1152,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1165,11 +1157,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "7de56acd5cc9642cac2a9518d4c8c53818905398fe42d33235859e0d542a7695"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -1470,7 +1461,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -1482,15 +1473,15 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.17",
+ "time 0.3.19",
  "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -1519,9 +1510,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1590,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "libc",
@@ -1610,9 +1601,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -1685,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1731,15 +1722,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2186,6 +2177,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdd927d1a3d5d98abcfc4cf8627371862ee6abfe52a988050621c50c66b4493"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "aruna-rust-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99691ccea4334d1de53d90c6a9f32ebebbcf35acc568788976e772d3589cce5c"
+checksum = "67ceb05370086253f95cfdacbf87711625208bd833d4673a2a69d63679a56401"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aruna_server"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aruna-rust-api",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,7 @@ dependencies = [
  "r2d2",
  "rand",
  "rand_core",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1228,6 +1238,8 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "aruna_server"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "aruna-rust-api",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "aruna_server"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 description = "Server application for AOS (Aruna Object Storage)"
 repository = "https://github.com/ArunaStorage/ArunaServer"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0.93"
 reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.45"
 toml = "0.7.2"
-aruna-rust-api = "1.0.0-rc.2"
+aruna-rust-api = "1.0.0-rc.4"
 bigdecimal = "0.3.0"
 regex = "1.7.1"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,9 @@ openssl = "0.10.45"
 toml = "0.7.2"
 aruna-rust-api = "1.0.0-rc.2"
 bigdecimal = "0.3.0"
+regex = "1.7.1"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 serial_test = "1.0.0"
-lazy_static = "1.4.0"
 url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 chrono = "0.4.23"
 diesel = {version = "2.0.3", features = ["postgres", "uuid", "r2d2", "chrono", "numeric"]}
-diesel-derive-enum = { version = "2.0.0-rc.0", features = ["postgres"] }
+diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
 dotenv = "0.15.0"
-http = "0.2.8"
-itertools = "0.10.3"
+http = "0.2.9"
+itertools = "0.10.5"
 log = "0.4.17"
 simple_logger = "4.0.0"
-prost = "0.11.6"
-prost-types = "0.11.6"
+prost = "0.11.7"
+prost-types = "0.11.7"
 tokio = {version = "1.25.0", features = ["full"]}
-tokio-stream = { version = "0.1.11", features = ["net"] }
+tokio-stream = { version = "0.1.12", features = ["net"] }
 tonic = "0.8.3"
 uuid = {version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics", "serde"]}
 r2d2 = { version = ">= 0.8.10, < 0.9.0"}
@@ -29,7 +29,7 @@ rand_core = "0.6.4"
 jsonwebtoken = "8.2.0"
 serde = {version = "1.0.152", features = ["derive"]}
 serde_json = "1.0.93"
-reqwest = {version = "0.11.11", features = ["json"] }
+reqwest = {version = "0.11.14", features = ["json"] }
 openssl = "0.10.45"
 toml = "0.7.2"
 aruna-rust-api = "1.0.0-rc.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "aruna_server"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 description = "Server application for AOS (Aruna Object Storage)"
 repository = "https://github.com/ArunaStorage/ArunaServer"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0.93"
 reqwest = {version = "0.11.11", features = ["json"] }
 openssl = "0.10.45"
 toml = "0.7.2"
-aruna-rust-api = "1.0.0-rc.4"
+aruna-rust-api = "1.0.0-rc.5"
 bigdecimal = "0.3.0"
 regex = "1.7.1"
 lazy_static = "1.4.0"

--- a/migrations/2023-02-03-103413_parallel_collection_object/down.sql
+++ b/migrations/2023-02-03-103413_parallel_collection_object/down.sql
@@ -1,3 +1,0 @@
--- This file should undo anything in `up.sql`
-ALTER TABLE collection_objects ADD CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id);
-DROP INDEX parallel_collection_object CASCADE;

--- a/migrations/2023-02-03-103413_parallel_collection_object/up.sql
+++ b/migrations/2023-02-03-103413_parallel_collection_object/up.sql
@@ -1,3 +1,0 @@
--- Your SQL goes here
-ALTER TABLE collection_objects ADD CONSTRAINT parallel_collection_object UNIQUE (object_id, collection_id, auto_update);
-DROP INDEX unique_collection_object CASCADE;

--- a/migrations/2023-02-13-113213_add_paths/down.sql
+++ b/migrations/2023-02-13-113213_add_paths/down.sql
@@ -1,2 +1,4 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS paths;
+DROP INDEX uniqe_collection_name_project_id CASCADE;
+DROP INDEX unique_project_name CASCADE;

--- a/migrations/2023-02-13-113213_add_paths/up.sql
+++ b/migrations/2023-02-13-113213_add_paths/up.sql
@@ -7,5 +7,10 @@ CREATE TABLE paths (
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     active BOOL NOT NULL DEFAULT FALSE,
     FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
-    UNIQUE (path, shared_revision_id, collection_id)
+    UNIQUE (path)
 );
+
+-- Add unique constraint for collection name and project_id 
+ALTER TABLE collections ADD CONSTRAINT uniqe_collection_name_project_id UNIQUE (project_id, name);
+-- Add unique constraint for project name
+ALTER TABLE projects ADD CONSTRAINT unique_project_name UNIQUE (name);

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -952,7 +952,7 @@ fn pin_collection_to_version(
     use crate::database::schema::required_labels::dsl as rlbl;
     use diesel::prelude::*;
 
-    let mut new_collection_overview = collection_overview.clone();
+    let mut new_collection_overview = collection_overview;
 
     // Query the original objects from the origin collection
     let original_objects: Vec<Object> = clobj::collection_objects
@@ -1032,7 +1032,7 @@ fn pin_collection_to_version(
     // Mapping table for objectgroups with key = original_uuid and value = new_uuid
     let mut object_group_mappings = HashMap::new();
     // Clone each object from old to new collection
-    for orig_obj in original_objects.clone() {
+    for orig_obj in original_objects {
         let (new_obj, new_revision_id) = clone_object(
             conn,
             &creator_user,
@@ -1041,7 +1041,7 @@ fn pin_collection_to_version(
             new_collection_overview.coll.id,
         )?;
 
-        match revision_id_mapping.entry(orig_obj.shared_revision_id.clone()) {
+        match revision_id_mapping.entry(orig_obj.shared_revision_id) {
             Entry::Occupied(_) => {}
             Entry::Vacant(_) => {
                 revision_id_mapping.insert(orig_obj.shared_revision_id, new_revision_id);
@@ -1208,7 +1208,7 @@ fn pin_paths_to_version(
     let mut modified_paths = Vec::new();
     for old_path in old_paths {
         // Split path in mutable parts for easier modification/replacement
-        let mut path_parts = old_path.path.split("/").collect::<Vec<_>>();
+        let mut path_parts = old_path.path.split('/').collect::<Vec<_>>();
 
         // Replace collection name in case of pin with collection update
         path_parts[2] = pin_collection.coll.name.as_str();
@@ -1225,7 +1225,7 @@ fn pin_paths_to_version(
                 .ok_or(ArunaError::InvalidRequest(
                     "Could not map old object to newly created.".to_string(),
                 ))?,
-            collection_id: pin_collection.coll.id.clone(),
+            collection_id: pin_collection.coll.id,
             created_at: Local::now().naive_local(),
             active: true,
         });

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -85,6 +85,13 @@ impl Database {
         use crate::database::schema::collections::dsl::*;
         use crate::database::schema::required_labels::dsl::*;
 
+        // Validate collection name against regex schema
+        if !NAME_SCHEMA.is_match(request.name.as_str()) {
+            return Err(ArunaError::InvalidRequest(
+                "Invalid collection name. Only ^[\\w~\\-.]+$ characters allowed.".to_string(),
+            ));
+        }
+
         // Create new collection uuid
         let collection_uuid = uuid::Uuid::new_v4();
         // Create new "shared_version_uuid"
@@ -343,8 +350,17 @@ impl Database {
         use crate::database::schema::collection_key_value::dsl as ckvdsl;
         use crate::database::schema::collections::dsl::*;
         use crate::database::schema::required_labels::dsl as reqlbl;
+
+        // Validate collection name against regex schema
+        if !NAME_SCHEMA.is_match(request.name.as_str()) {
+            return Err(ArunaError::InvalidRequest(
+                "Invalid collection name. Only ^[\\w~\\-.]+$ characters allowed.".to_string(),
+            ));
+        }
+
         // Query the old collection id that should be updated
         let old_collection_id = uuid::Uuid::parse_str(&request.collection_id)?;
+
         // Execute request in transaction
         let ret_collections = self
             .pg_connection

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -1222,7 +1222,9 @@ fn pin_paths_to_version(
             path: path_parts.join("/").to_string(),
             shared_revision_id: *revision_id_mapping
                 .get(&old_path.shared_revision_id)
-                .ok_or(ArunaError::InvalidRequest("Could not map old object to new  ".to_string()))?,
+                .ok_or(ArunaError::InvalidRequest(
+                    "Could not map old object to newly created.".to_string(),
+                ))?,
             collection_id: pin_collection.coll.id.clone(),
             created_at: Local::now().naive_local(),
             active: true,

--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -11,7 +11,7 @@
 use super::utils::*;
 use crate::database;
 use crate::database::connection::Database;
-use crate::database::crud::object::{clone_object, safe_delete_object};
+use crate::database::crud::object::{clone_object, delete_multiple_objects};
 use crate::database::models;
 use crate::database::models::collection::{
     Collection, CollectionKeyValue, CollectionObject, CollectionObjectGroup, CollectionVersion,
@@ -639,16 +639,16 @@ impl Database {
             .collect::<Vec<_>>();
             if !all_obj_ids.is_empty() {
                 //delete_multiple_objects(all_obj_ids, collection_id, true, false, user_id, conn)?;
-                for object_uuid in all_obj_ids {
-                    safe_delete_object(
-                        &object_uuid,
-                    &collection_id,
+                //for object_uuid in all_obj_ids {
+                    delete_multiple_objects(
+                        all_obj_ids,
+                    collection_id,
                     true,
                     false,
                         user_id,
                         conn
                     )?;
-                }
+                //}
             }
             // Delete all collection_key_values
             delete(

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -74,7 +74,7 @@ lazy_static! {
     /// 2. Too large Regex
     /// Both cases should be checked in tests and should result in safe behaviour because
     /// the string is static.
-    static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+/?)*$").unwrap();
+    static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+)*/?$").unwrap();
 }
 
 // Struct to hold a database object with all its assets

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -54,7 +54,6 @@ use crate::database::models::enums::{
 use crate::database::models::object::{
     Endpoint, Hash as ApiHash, Object, ObjectKeyValue, ObjectLocation, Source,
 };
-use regex::Regex;
 
 use crate::database::schema::{
     collection_object_groups::dsl::*, collection_objects::dsl::*, collection_version::dsl::*,
@@ -64,18 +63,7 @@ use crate::database::schema::{
 };
 
 use super::objectgroups::bump_revisisions;
-use super::utils::validate_key_values;
-use super::utils::{grpc_to_db_dataclass, ParsedQuery};
-
-lazy_static! {
-    /// This unwrap should be okay if this Regex is covered and used in tests
-    /// Only two cases result in failure for Regex::new
-    /// 1. Invalid regex syntax
-    /// 2. Too large Regex
-    /// Both cases should be checked in tests and should result in safe behaviour because
-    /// the string is static.
-    static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+)*/?$").unwrap();
-}
+use super::utils::*;
 
 // Struct to hold a database object with all its assets
 #[derive(Debug, Clone)]

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1304,6 +1304,13 @@ impl Database {
                     ));
                 }
 
+                // Auto_update reference can only be created for latest revision to ensure reference consistency
+                if request.auto_update && !original_reference.is_latest {
+                    return Err(ArunaError::InvalidRequest(
+                        "Cannot create auto_update reference for non-latest revision.".to_string(),
+                    ));
+                }
+
                 let collection_object = CollectionObject {
                     id: uuid::Uuid::new_v4(),
                     collection_id: target_collection_uuid,

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1292,12 +1292,12 @@ impl Database {
         // Transaction time
         self.pg_connection
             .get()?
-            .transaction::<_, Error, _>(|conn| {
+            .transaction::<_, ArunaError, _>(|conn| {
                 // Return error if target collection already has a version
-                if is_collection_versioned(conn, &target_collection_uuid) {
-                    Err(ArunaError::InvalidRequest(
+                if is_collection_versioned(conn, &target_collection_uuid)? {
+                    return Err(ArunaError::InvalidRequest(
                         "Adding objects to collection with version is forbidden.".to_string(),
-                    ))
+                    ));
                 }
 
                 // Get collection_object association of original object

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -2014,6 +2014,7 @@ pub fn update_object_in_place(
 
     delete(object_key_value)
         .filter(database::schema::object_key_value::object_id.eq(&object_uuid))
+        .filter(database::schema::object_key_value::key.not_ilike("%app.aruna-storage.org%"))
         .execute(conn)?;
     insert_into(object_key_value)
         .values(&key_value_pairs)

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1297,6 +1297,13 @@ impl Database {
                     )
                     .first::<CollectionObject>(conn)?;
 
+                // Check if reference is staging object
+                if original_reference.reference_status == ReferenceStatus::STAGING {
+                    return Err(ArunaError::InvalidRequest(
+                        "Cannot create reference of object while in staging phase.".to_string(),
+                    ));
+                }
+
                 let collection_object = CollectionObject {
                     id: uuid::Uuid::new_v4(),
                     collection_id: target_collection_uuid,

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1293,6 +1293,11 @@ impl Database {
         self.pg_connection
             .get()?
             .transaction::<_, Error, _>(|conn| {
+                // Return error if target collection already has a version
+                if is_collection_versioned(conn, &target_collection_uuid) {
+                    Err(ArunaError::InvalidRequest("Adding objects to collection with version is forbidden.".to_string()))
+                }
+
                 // Get collection_object association of original object
                 let original_reference: CollectionObject = collection_objects
                     .filter(database::schema::collection_objects::object_id.eq(&object_uuid))

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1725,16 +1725,14 @@ impl Database {
         self.pg_connection
             .get()?
             .transaction::<_, ArunaError, _>(|conn| {
-                for object_uuid in parsed_object_ids {
-                    delete_multiple_objects(
-                        vec![object_uuid],
-                        parsed_collection_id,
-                        request.force,
-                        request.with_revisions,
-                        creator_id,
-                        conn,
-                    )?;
-                }
+                delete_multiple_objects(
+                    parsed_object_ids,
+                    parsed_collection_id,
+                    request.force,
+                    request.with_revisions,
+                    creator_id,
+                    conn,
+                )?;
 
                 Ok(())
             })?;

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -2238,9 +2238,7 @@ pub fn clone_object(
     }
 
     // Insert cloned object, hash, key_Values and references
-    insert_into(objects)
-        .values(&db_object)
-        .execute(conn)?;
+    insert_into(objects).values(&db_object).execute(conn)?;
     // Insert cloned locations
     insert_into(object_locations)
         .values(&db_locations)

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -2874,7 +2874,9 @@ pub fn delete_multiple_objects(
                         }
                     }
                 }
-                objects_to_trash.push(writeable_object);
+                if !other_reference_found {
+                    objects_to_trash.push(writeable_object);
+                }
                 objects_to_trash.append(&mut potential_trash)
             }
         }

--- a/src/database/crud/objectgroups.rs
+++ b/src/database/crud/objectgroups.rs
@@ -126,7 +126,7 @@ impl Database {
             .get()?
             .transaction::<ObjectGroupDb, ArunaError, _>(|conn| {
                 // Validate that request does not contain staging objects
-                if collection_objects
+                if !collection_objects
                     .filter(database::schema::collection_objects::object_id.eq_any(&obj_uuids))
                     .filter(
                         database::schema::collection_objects::reference_status
@@ -135,8 +135,7 @@ impl Database {
                     .load::<CollectionObject>(conn)
                     .optional()?
                     .unwrap_or_default()
-                    .len()
-                    > 0
+                    .is_empty()
                 {
                     return Err(ArunaError::InvalidRequest(
                         "Cannot create object group with staging objects.".to_string(),
@@ -244,7 +243,7 @@ impl Database {
             .get()?
             .transaction::<ObjectGroupDb, ArunaError, _>(|conn| {
                 // Validate that request does not contain staging objects
-                if collection_objects
+                if !collection_objects
                     .filter(database::schema::collection_objects::object_id.eq_any(&obj_uuids))
                     .filter(
                         database::schema::collection_objects::reference_status
@@ -253,8 +252,7 @@ impl Database {
                     .load::<CollectionObject>(conn)
                     .optional()?
                     .unwrap_or_default()
-                    .len()
-                    > 0
+                    .is_empty()
                 {
                     return Err(ArunaError::InvalidRequest(
                         "Cannot create object group with staging objects.".to_string(),

--- a/src/database/crud/project.rs
+++ b/src/database/crud/project.rs
@@ -49,6 +49,13 @@ impl Database {
         use crate::database::schema::user_permissions::dsl as user_perm;
         use diesel::result::Error as dError;
 
+        // Validate project name against regex schema
+        if !NAME_SCHEMA.is_match(request.name.as_str()) {
+            return Err(ArunaError::InvalidRequest(
+                "Invalid project name. Only ^[\\w~\\-.]+$ characters allowed.".to_string(),
+            ));
+        }
+
         // Create a new uuid for the project
         let project_id = uuid::Uuid::new_v4();
 
@@ -431,6 +438,14 @@ impl Database {
         use crate::database::schema::projects::dsl::*;
         use crate::database::schema::user_permissions::dsl::*;
         use diesel::result::Error as dError;
+
+        // Validate project name against regex schema
+        if !NAME_SCHEMA.is_match(request.name.as_str()) {
+            return Err(ArunaError::InvalidRequest(
+                "Invalid project name. Only ^[\\w~\\-.]+$ characters allowed.".to_string(),
+            ));
+        }
+
         // Get project_id
         let p_id = uuid::Uuid::parse_str(&request.project_id)?;
 

--- a/src/database/crud/user.rs
+++ b/src/database/crud/user.rs
@@ -142,9 +142,9 @@ impl Database {
         let expiry_time = request.expires_at.clone();
         // Parse it to Option<NaiveDateTime>
         let exp_time = match expiry_time {
-            Some(t) => t
-                .timestamp
-                .map(|t| chrono::NaiveDateTime::from_timestamp(t.seconds, 0)),
+            Some(t) => t.timestamp.map(|t| {
+                chrono::NaiveDateTime::from_timestamp_opt(t.seconds, 0).unwrap_or_default()
+            }),
             None => None,
         };
 

--- a/src/database/crud/utils.rs
+++ b/src/database/crud/utils.rs
@@ -21,7 +21,7 @@ lazy_static! {
     /// Both cases should be checked in tests and should result in safe behaviour because
     /// the string is static.
     pub static ref NAME_SCHEMA: Regex = Regex::new(r"^[\w~\-.]+$").unwrap();
-    pub static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+)*/?$").unwrap();
+    pub static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+)+/?$").unwrap();
 }
 
 /// Converts a chrono::NaiveDateTime to a prost_types::Timestamp

--- a/src/database/crud/utils.rs
+++ b/src/database/crud/utils.rs
@@ -153,7 +153,7 @@ where
     // For now we only check if all keys do not contain the aruna substring -> this is a reserved name
     key_values
         .into_iter()
-        .all(|e| !e.get_key().contains("aruna"))
+        .all(|e| !e.get_key().to_lowercase().contains("aruna"))
 }
 
 /// This helper function maps gRPC permissions to

--- a/src/database/crud/utils.rs
+++ b/src/database/crud/utils.rs
@@ -12,6 +12,18 @@ use crate::database::models::traits::{IsKeyValue, ToDbKeyValue};
 use crate::error::ArunaError;
 use crate::error::TypeConversionError::PROTOCONVERSION;
 
+use regex::Regex;
+lazy_static! {
+    /// This unwrap should be okay if this Regex is covered and used in tests
+    /// Only two cases result in failure for Regex::new
+    /// 1. Invalid regex syntax
+    /// 2. Too large Regex
+    /// Both cases should be checked in tests and should result in safe behaviour because
+    /// the string is static.
+    pub static ref NAME_SCHEMA: Regex = Regex::new(r"^[\w~\-.]+$").unwrap();
+    pub static ref PATH_SCHEMA: Regex = Regex::new(r"^(/?[\w~\-.]+)*/?$").unwrap();
+}
+
 /// Converts a chrono::NaiveDateTime to a prost_types::Timestamp
 /// This converts types with the `as` keyword. It should be safe
 /// because hours, minutes etc. should never exceed the u8 bounds.

--- a/src/database/crud/utils.rs
+++ b/src/database/crud/utils.rs
@@ -135,6 +135,27 @@ where
     )
 }
 
+/// This is a generic validation function for all kinds of key_values
+///
+/// ## Arguments
+///
+/// * `key_values` - A vector containing DbKeyValues
+///
+/// ## Returns
+///
+/// * `bool` - true if validated, false if not
+/// * `Vec<KeyValue>` - A vector containing the hook key-value pairs
+///
+pub fn validate_key_values<T>(key_values: Vec<T>) -> bool
+where
+    T: IsKeyValue,
+{
+    // For now we only check if all keys do not contain the aruna substring -> this is a reserved name
+    key_values
+        .into_iter()
+        .all(|e| !e.get_key().contains("aruna"))
+}
+
 /// This helper function maps gRPC permissions to
 /// associated DB user_rights, it is mainly used in the creation of new api_tokens
 ///

--- a/src/database/models/enums.rs
+++ b/src/database/models/enums.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use tonic::{Code, Status};
 
 #[derive(Debug, DbEnum, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[DieselTypePath = "sql_types::ObjectStatus"]
+#[ExistingTypePath = "sql_types::ObjectStatus"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum ObjectStatus {
     INITIALIZING,
@@ -18,7 +18,7 @@ pub enum ObjectStatus {
 }
 
 #[derive(Clone, Copy, Debug, DbEnum, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
-#[DieselTypePath = "sql_types::EndpointType"]
+#[ExistingTypePath = "sql_types::EndpointType"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum EndpointType {
     S3,
@@ -50,7 +50,7 @@ impl FromStr for EndpointType {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[DieselTypePath = "sql_types::Dataclass"]
+#[ExistingTypePath = "sql_types::Dataclass"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum Dataclass {
     PUBLIC,
@@ -60,7 +60,7 @@ pub enum Dataclass {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[DieselTypePath = "sql_types::SourceType"]
+#[ExistingTypePath = "sql_types::SourceType"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum SourceType {
     URL,
@@ -77,7 +77,7 @@ impl SourceType {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[DieselTypePath = "sql_types::HashType"]
+#[ExistingTypePath = "sql_types::HashType"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum HashType {
     MD5,
@@ -102,7 +102,7 @@ impl HashType {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq)]
-#[DieselTypePath = "sql_types::KeyValueType"]
+#[ExistingTypePath = "sql_types::KeyValueType"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum KeyValueType {
     LABEL,
@@ -110,14 +110,14 @@ pub enum KeyValueType {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy)]
-#[DieselTypePath = "sql_types::IdentityProviderType"]
+#[ExistingTypePath = "sql_types::IdentityProviderType"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum IdentityProviderType {
     OIDC,
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[DieselTypePath = "sql_types::UserRights"]
+#[ExistingTypePath = "sql_types::UserRights"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum UserRights {
     NONE,
@@ -129,7 +129,7 @@ pub enum UserRights {
 }
 
 #[derive(Debug, DbEnum, PartialEq, Eq, Clone, Copy)]
-#[DieselTypePath = "sql_types::Resources"]
+#[ExistingTypePath = "sql_types::Resources"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum Resources {
     PROJECT,
@@ -139,7 +139,7 @@ pub enum Resources {
 }
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, PartialOrd)]
-#[DieselTypePath = "sql_types::ReferenceStatus"]
+#[ExistingTypePath = "sql_types::ReferenceStatus"]
 #[DbValueStyle = "UPPERCASE"]
 pub enum ReferenceStatus {
     STAGING,

--- a/src/database/models/object.rs
+++ b/src/database/models/object.rs
@@ -2,6 +2,7 @@ use super::auth::*;
 use super::enums::*;
 use super::traits::IsKeyValue;
 use super::traits::ToDbKeyValue;
+use crate::database::models::collection::Collection;
 use crate::database::schema::*;
 use uuid;
 
@@ -124,6 +125,18 @@ impl ToDbKeyValue for ObjectKeyValue {
             key_value_type: kv_type,
         }
     }
+}
+
+#[derive(Associations, Queryable, Insertable, Identifiable, Selectable, Debug, Clone)]
+#[diesel(table_name = paths)]
+#[diesel(belongs_to(Collection))]
+pub struct Path {
+    pub id: uuid::Uuid,
+    pub path: String,
+    pub shared_revision_id: uuid::Uuid,
+    pub collection_id: uuid::Uuid,
+    pub created_at: chrono::NaiveDateTime,
+    pub active: bool,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate diesel;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod config;
 pub mod database;
 pub mod error;

--- a/src/server/services/internal_proxy_notifier.rs
+++ b/src/server/services/internal_proxy_notifier.rs
@@ -1,0 +1,36 @@
+use super::authz::Authz;
+use crate::database::connection::Database;
+
+use aruna_rust_api::api::internal::v1::internal_proxy_notifier_service_server::InternalProxyNotifierService;
+use aruna_rust_api::api::internal::v1::{
+    FinalizeObjectRequest, FinalizeObjectResponse, GetEncryptionKeyRequest,
+    GetEncryptionKeyResponse,
+};
+use std::sync::Arc;
+use tonic::{Request, Response, Status};
+
+// This macro automatically creates the Impl struct with all associated fields
+crate::impl_grpc_server!(InternalProxyNotifierServiceImpl);
+
+/// Trait created by tonic based on gRPC service definitions from .proto files.
+///   The source .proto files are defined in the ArunaStorage/ArunaAPI repo.
+#[tonic::async_trait]
+impl InternalProxyNotifierService for InternalProxyNotifierServiceImpl {
+    async fn finalize_object(
+        &self,
+        _request: Request<FinalizeObjectRequest>,
+    ) -> Result<Response<FinalizeObjectResponse>, Status> {
+        Err(Status::unimplemented(
+            "This service call is not yet implemented.",
+        ))
+    }
+
+    async fn get_encryption_key(
+        &self,
+        _request: Request<GetEncryptionKeyRequest>,
+    ) -> Result<Response<GetEncryptionKeyResponse>, Status> {
+        Err(Status::unimplemented(
+            "This service call is not yet implemented.",
+        ))
+    }
+}

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -12,3 +12,4 @@ pub mod utils;
 
 pub mod internal_authorize;
 pub mod internal_notifications;
+pub mod internal_proxy_notifier;

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -12,7 +12,10 @@ use crate::error::ArunaError;
 use crate::server::services::authz::{Authz, Context};
 use crate::server::services::utils::{format_grpc_request, format_grpc_response};
 use aruna_rust_api::api::internal::v1::internal_proxy_service_client::InternalProxyServiceClient;
-use aruna_rust_api::api::internal::v1::*;
+use aruna_rust_api::api::internal::v1::{
+    CreatePresignedDownloadRequest, CreatePresignedUploadUrlRequest, FinishPresignedUploadRequest,
+    InitPresignedUploadRequest, Location, PartETag, Range,
+};
 use aruna_rust_api::api::storage::models::v1::Object;
 use aruna_rust_api::api::storage::{
     services::v1::object_service_server::ObjectService, services::v1::*,

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -1214,7 +1214,7 @@ impl ObjectService for ObjectServiceImpl {
     /// !! Paths are collection specific !!
     async fn get_object_path(
         &self,
-        request: tonic::Request<GetObjectPathRequest>,
+        _request: tonic::Request<GetObjectPathRequest>,
     ) -> Result<tonic::Response<GetObjectPathResponse>, tonic::Status> {
         todo!()
     }
@@ -1226,7 +1226,7 @@ impl ObjectService for ObjectServiceImpl {
     /// !! Paths are collection specific !!
     async fn get_object_paths(
         &self,
-        request: tonic::Request<GetObjectPathsRequest>,
+        _request: tonic::Request<GetObjectPathsRequest>,
     ) -> Result<tonic::Response<GetObjectPathsResponse>, tonic::Status> {
         todo!()
     }
@@ -1238,7 +1238,7 @@ impl ObjectService for ObjectServiceImpl {
     /// !! Paths are collection specific !!
     async fn create_object_path(
         &self,
-        request: tonic::Request<CreateObjectPathRequest>,
+        _request: tonic::Request<CreateObjectPathRequest>,
     ) -> Result<tonic::Response<CreateObjectPathResponse>, tonic::Status> {
         todo!()
     }
@@ -1250,7 +1250,7 @@ impl ObjectService for ObjectServiceImpl {
     /// !! Paths are collection specific !!
     async fn set_object_path_visibility(
         &self,
-        request: tonic::Request<SetObjectPathVisibilityRequest>,
+        _request: tonic::Request<SetObjectPathVisibilityRequest>,
     ) -> Result<tonic::Response<SetObjectPathVisibilityResponse>, tonic::Status> {
         todo!()
     }
@@ -1262,7 +1262,7 @@ impl ObjectService for ObjectServiceImpl {
     /// !! Paths are collection specific !!
     async fn get_objects_by_path(
         &self,
-        request: tonic::Request<GetObjectsByPathRequest>,
+        _request: tonic::Request<GetObjectsByPathRequest>,
     ) -> Result<tonic::Response<GetObjectsByPathResponse>, tonic::Status> {
         todo!()
     }

--- a/tests/b1_authz_test.rs
+++ b/tests/b1_authz_test.rs
@@ -619,8 +619,8 @@ fn get_user_projects_test() {
 
     // Create project as admin
     let crt_proj_req = CreateProjectRequest {
-        name: "testproj_1".to_string(),
-        description: "".to_string(),
+        name: "get_user_projects_test_project_001".to_string(),
+        description: "First project created in get_user_projects_test()".to_string(),
     };
     let proj_1 = db
         .create_project(
@@ -642,8 +642,8 @@ fn get_user_projects_test() {
 
     // Create project as user
     let crt_proj_req_2 = CreateProjectRequest {
-        name: "testproj_2".to_string(),
-        description: "".to_string(),
+        name: "get_user_projects_test_project_002".to_string(),
+        description: "Second project created in get_user_projects_test()".to_string(),
     };
     // This should add the user automatically
     let _proj_2 = db.create_project(crt_proj_req_2, user_id).unwrap();

--- a/tests/b2_authz_user_grpc_test.rs
+++ b/tests/b2_authz_user_grpc_test.rs
@@ -75,7 +75,7 @@ async fn register_user_grpc_test() {
     assert!(!user_id.is_empty());
 
     let req = common::grpc_helpers::add_token(
-        tonic::Request::new(ActivateUserRequest { user_id: user_id }),
+        tonic::Request::new(ActivateUserRequest { user_id }),
         common::oidc::ADMINTOKEN,
     );
 

--- a/tests/b2_authz_user_grpc_test.rs
+++ b/tests/b2_authz_user_grpc_test.rs
@@ -71,7 +71,15 @@ async fn register_user_grpc_test() {
 
     println!("{:#?}", resp);
     assert!(resp.is_ok());
-    assert!(!resp.unwrap().into_inner().user_id.is_empty());
+    let user_id = resp.unwrap().into_inner().user_id;
+    assert!(!user_id.is_empty());
+
+    let req = common::grpc_helpers::add_token(
+        tonic::Request::new(ActivateUserRequest { user_id: user_id }),
+        common::oidc::ADMINTOKEN,
+    );
+
+    let _resp = userservice.activate_user(req).await.unwrap();
 }
 
 #[ignore]

--- a/tests/c1_project_tests.rs
+++ b/tests/c1_project_tests.rs
@@ -59,7 +59,7 @@ fn update_project_test() {
     assert!(!project_id.is_nil());
 
     // Update empty project metadata
-    let updated_name = "Updated Project Name".to_string();
+    let updated_name = "Updated-Project-Name".to_string();
     let updated_description = "Updated project description".to_string();
     let update_request = UpdateProjectRequest {
         project_id: project_id.to_string(),
@@ -163,8 +163,8 @@ fn add_remove_project_user_test() {
 
     // Create project
     let create_request = CreateProjectRequest {
-        name: "".to_string(),
-        description: "".to_string(),
+        name: "add_remove_project_user_test_project".to_string(),
+        description: "Project created for add_remove_project_user_test()".to_string(),
     };
     let create_response = db.create_project(create_request, creator).unwrap();
 

--- a/tests/c1_project_tests.rs
+++ b/tests/c1_project_tests.rs
@@ -28,8 +28,8 @@ fn create_project_test() {
     let creator = uuid::Uuid::parse_str("12345678-1234-1234-1234-111111111111").unwrap();
 
     let request = CreateProjectRequest {
-        name: "".to_string(),
-        description: "".to_string(),
+        name: "create_project_test_project".to_string(),
+        description: "Project created in create_project_test()".to_string(),
     };
 
     let response = db.create_project(request, creator).unwrap();
@@ -116,9 +116,9 @@ fn destroy_non_empty_project_test() {
     let db = database::connection::Database::new("postgres://root:test123@localhost:26257/test");
     let creator = uuid::Uuid::parse_str("12345678-1234-1234-1234-111111111111").unwrap();
 
-    let _created_project = common::functions::create_project(None);
+    let created_project = common::functions::create_project(None);
     // Validate creation
-    let project_id = uuid::Uuid::parse_str(&_created_project.id).unwrap();
+    let project_id = uuid::Uuid::parse_str(&created_project.id).unwrap();
     assert!(!project_id.is_nil());
 
     // Create collection in project
@@ -245,8 +245,8 @@ fn edit_project_user_permissions_test() {
 
     // Create project
     let create_request = CreateProjectRequest {
-        name: "".to_string(),
-        description: "".to_string(),
+        name: "edit_project_user_permissions_test_project".to_string(),
+        description: "Project created in edit_project_user_permissions_test()".to_string(),
     };
     let create_response = db.create_project(create_request, creator).unwrap();
 

--- a/tests/c2_project_grpc_tests.rs
+++ b/tests/c2_project_grpc_tests.rs
@@ -35,7 +35,7 @@ async fn create_project_grpc_test() {
     // Create gPC Request for project creation
     let create_project_request = common::grpc_helpers::add_token(
         tonic::Request::new(CreateProjectRequest {
-            name: "Test Project".to_string(),
+            name: "Test-Project".to_string(),
             description: "This project was created in create_project_grpc_test().".to_string(),
         }),
         common::oidc::ADMINTOKEN,
@@ -171,11 +171,11 @@ async fn update_project_grpc_test() {
     // Fast track project creation
     let orig_project = common::functions::create_project(None);
 
-    // Create gPC Request to update single project name and description
+    // Create gRPC Request to update single project name and description
     let update_project_request = common::grpc_helpers::add_token(
         tonic::Request::new(UpdateProjectRequest {
             project_id: orig_project.id.to_string(),
-            name: "Updated Project".to_string(),
+            name: "Updated-Project".to_string(),
             description: "This project was updated in update_project_grpc_test().".to_string(),
         }),
         common::oidc::ADMINTOKEN,
@@ -190,7 +190,7 @@ async fn update_project_grpc_test() {
     let updated_project = update_project_response.project.unwrap();
 
     assert_eq!(orig_project.id, updated_project.id);
-    assert_eq!(updated_project.name, "Updated Project".to_string());
+    assert_eq!(updated_project.name, "Updated-Project".to_string());
     assert_eq!(
         updated_project.description,
         "This project was updated in update_project_grpc_test().".to_string()

--- a/tests/common/functions.rs
+++ b/tests/common/functions.rs
@@ -300,7 +300,11 @@ pub fn create_object(object_info: &TCreateObject) -> Object {
     } else {
         uuid::Uuid::parse_str("12345678-6666-6666-6666-999999999999").unwrap()
     };
-    let sub_path = &object_info.sub_path.unwrap_or_default();
+    let sub_path = if let Some(whatev) = &object_info.sub_path {
+        whatev.to_string()
+    } else {
+        "".to_string()
+    };
 
     // Initialize Object with random values
     let object_id = uuid::Uuid::new_v4();
@@ -334,7 +338,7 @@ pub fn create_object(object_info: &TCreateObject) -> Object {
         preferred_endpoint_id: endpoint_id.to_string(),
         multipart: false,
         is_specification: false,
-        hash: *object_info.init_hash,
+        hash: object_info.init_hash.clone(),
     };
 
     let dummy_location = Location {
@@ -403,7 +407,7 @@ pub fn get_object(collection_id: String, object_id: String) -> Object {
     };
     let object = db.get_object(&get_request).unwrap();
 
-    object.unwrap()
+    object.object.unwrap()
 }
 
 /// GetReferences wrapper for simplified use in tests.
@@ -485,8 +489,11 @@ pub fn update_object(update: &TCreateUpdate) -> Object {
         update.content_len
     };
 
-    let sub_path = update.new_sub_path.unwrap_or_default();
-
+    let sub_path = if let Some(whatev) = &update.new_sub_path {
+        whatev.to_string()
+    } else {
+        "".to_string()
+    };
     // Update Object
     let updated_object_id_001 = uuid::Uuid::new_v4();
     let updated_upload_id = uuid::Uuid::new_v4();
@@ -512,7 +519,7 @@ pub fn update_object(update: &TCreateUpdate) -> Object {
         preferred_endpoint_id: "".to_string(),
         multi_part: false,
         is_specification: false,
-        hash: *update.init_hash,
+        hash: update.init_hash.clone(),
     };
 
     let update_response = db

--- a/tests/d1_collection_tests.rs
+++ b/tests/d1_collection_tests.rs
@@ -539,8 +539,8 @@ fn update_collection_test() {
 
     let normal_update = UpdateCollectionRequest {
         collection_id: col_id.to_string(),
-        name: "new_name".to_string(),
-        description: "new_descrpt".to_string(),
+        name: "update_collection_test_collection_001".to_string(),
+        description: "First collection update in update_collection_test()".to_string(),
         labels: vec![KeyValue {
             key: "test_key".to_owned(),
             value: "test_value".to_owned(),
@@ -560,8 +560,8 @@ fn update_collection_test() {
 
     let pin_update = UpdateCollectionRequest {
         collection_id: col_id.to_string(),
-        name: "new_name".to_string(),
-        description: "new_descrpt".to_string(),
+        name: "update_collection_test_collection_fail".to_string(),
+        description: "Second collection update in update_collection_test()".to_string(),
         labels: vec![KeyValue {
             key: "test_key_2".to_owned(),
             value: "test_value_2".to_owned(),
@@ -587,8 +587,8 @@ fn update_collection_test() {
 
     let pin_update = UpdateCollectionRequest {
         collection_id: col_id.to_string(),
-        name: "new_name".to_string(),
-        description: "new_descrpt".to_string(),
+        name: "update_collection_test_collection_versioned".to_string(),
+        description: "Second collection update in update_collection_test()".to_string(),
         labels: vec![KeyValue {
             key: "test_key_2".to_owned(),
             value: "test_value_2".to_owned(),
@@ -620,8 +620,8 @@ fn pin_collection_test() {
     let creator = uuid::Uuid::parse_str("12345678-1234-1234-1234-111111111111").unwrap();
 
     let request = CreateNewCollectionRequest {
-        name: "new_collection_update".to_owned(),
-        description: "this_is_a_demo_collection_update".to_owned(),
+        name: "pin_collection_test_collection_001".to_owned(),
+        description: "Collection created in update_collection_test()".to_owned(),
         project_id: "12345678-1111-1111-1111-111111111111".to_owned(),
         label_ontology: None,
         labels: vec![KeyValue {

--- a/tests/d1_collection_tests.rs
+++ b/tests/d1_collection_tests.rs
@@ -974,8 +974,9 @@ pub fn test_collection_materialized_views_stats() {
 
     // Create fresh Project
     let create_project_request = CreateProjectRequest {
-        name: "Object creation test project".to_string(),
-        description: "Test project used in object creation test.".to_string(),
+        name: "test_collection_materialized_views_stats_project".to_string(),
+        description: "Collection created for test_collection_materialized_views_stats()"
+            .to_string(),
     };
 
     let create_project_response = db.create_project(create_project_request, creator).unwrap();
@@ -985,8 +986,8 @@ pub fn test_collection_materialized_views_stats() {
 
     // Create Collection
     let create_collection_request = CreateNewCollectionRequest {
-        name: "Object creation test project collection".to_string(),
-        description: "Test collection used in object creation test.".to_string(),
+        name: "test_collection_materialized_views_stats_collection".to_string(),
+        description: "Test collection used in materialized view stats test.".to_string(),
         label_ontology: None,
         project_id: project_id.to_string(),
         labels: vec![],

--- a/tests/d2_collection_grpc_tests.rs
+++ b/tests/d2_collection_grpc_tests.rs
@@ -198,10 +198,8 @@ async fn get_collection_grpc_test() {
     // Fast track collection creation
     let random_collection = common::functions::create_collection(TCreateCollection {
         project_id: random_project.id.to_string(),
-        num_labels: 0,
-        num_hooks: 0,
-        col_override: None,
         creator_id: Some(user_id.clone()),
+        ..Default::default()
     });
 
     // Get collection information with varying permissions

--- a/tests/d2_collection_grpc_tests.rs
+++ b/tests/d2_collection_grpc_tests.rs
@@ -867,7 +867,7 @@ async fn pin_collection_grpc_test() {
 
     let mut versioned_collection_option: Option<CollectionOverview> = None;
     // Pin collection with varying permissions
-    for permission in vec![
+    for (index, permission) in vec![
         Permission::None,
         Permission::Read,
         Permission::Append,
@@ -875,6 +875,7 @@ async fn pin_collection_grpc_test() {
         Permission::Admin,
     ]
     .iter()
+    .enumerate()
     {
         // Fast track permission edit
         let edit_perm = common::grpc_helpers::edit_project_permission(
@@ -891,7 +892,7 @@ async fn pin_collection_grpc_test() {
             tonic::Request::new(PinCollectionVersionRequest {
                 collection_id: random_collection.id.to_string(),
                 version: Some(Version {
-                    major: 3,
+                    major: index as i32,
                     minor: 2,
                     patch: 1,
                 }),
@@ -908,8 +909,6 @@ async fn pin_collection_grpc_test() {
                 assert!(pin_collection_response.is_err());
             }
             Permission::Modify | Permission::Admin => {
-                assert!(pin_collection_response.is_ok());
-
                 // Validate collection information returned from pin
                 let collection = pin_collection_response
                     .unwrap()
@@ -989,8 +988,8 @@ async fn pin_collection_grpc_test() {
                 collection_id: versioned_collection.id.to_string(),
                 version: Some(Version {
                     major: 4,
-                    minor: 0,
-                    patch: 0,
+                    minor: 5,
+                    patch: 7,
                 }),
             }),
             common::oidc::REGULARTOKEN, // At this point has project ADMIN permissions
@@ -998,8 +997,6 @@ async fn pin_collection_grpc_test() {
         let pin_collection_response = collection_service
             .pin_collection_version(pin_collection_grpc_request)
             .await;
-
-        assert!(pin_collection_response.is_ok());
 
         let ultra_versioned_collection = pin_collection_response
             .unwrap()

--- a/tests/d2_collection_grpc_tests.rs
+++ b/tests/d2_collection_grpc_tests.rs
@@ -74,7 +74,7 @@ async fn create_collection_grpc_test() {
 
     // Create gRPC request for collection creation
     let mut create_collection_request = CreateNewCollectionRequest {
-        name: "Test Collection".to_string(),
+        name: "Test-Collection".to_string(),
         description: "".to_string(),
         project_id: random_project.id.to_string(),
         labels: vec![KeyValue {
@@ -329,7 +329,7 @@ async fn get_collections_grpc_test() {
     {
         let create_collection_request = common::grpc_helpers::add_token(
             tonic::Request::new(CreateNewCollectionRequest {
-                name: format!("Test Collection 00{}", index).to_string(),
+                name: format!("Test-Collection-00{}", index).to_string(),
                 description: "Created for get_collections_grpc_test().".to_string(),
                 project_id: random_project.id.to_string(),
                 labels: labels.clone(),
@@ -527,7 +527,7 @@ async fn get_collections_grpc_test() {
         .collection_overviews;
 
     assert_eq!(collections.len(), 1);
-    assert_eq!(collections[0].name, "Test Collection 000".to_string());
+    assert_eq!(collections[0].name, "Test-Collection-000".to_string());
     assert_eq!(
         collections[0].description,
         "Created for get_collections_grpc_test().".to_string()
@@ -608,7 +608,7 @@ async fn update_collection_grpc_test() {
         let update_collection_grpc_request = common::grpc_helpers::add_token(
             tonic::Request::new(UpdateCollectionRequest {
                 collection_id: random_collection.id.to_string(),
-                name: "Test Collection".to_string(),
+                name: "Test-Collection".to_string(),
                 description: format!(
                     "Collection updated with permission {}",
                     permission.as_str_name()
@@ -644,7 +644,7 @@ async fn update_collection_grpc_test() {
                     .unwrap();
 
                 assert_eq!(collection.id, random_collection.id);
-                assert_eq!(collection.name, "Test Collection".to_string());
+                assert_eq!(collection.name, "Test-Collection".to_string());
                 assert_eq!(
                     collection.description,
                     format!(
@@ -676,7 +676,7 @@ async fn update_collection_grpc_test() {
     let pin_update_collection_request = common::grpc_helpers::add_token(
         tonic::Request::new(UpdateCollectionRequest {
             collection_id: random_collection.id.to_string(),
-            name: "Test Collection".to_string(),
+            name: "Test-Collection".to_string(),
             description: "Collection updated with version 1.2.3.".to_string(),
             labels: vec![KeyValue {
                 key: "is_versioned".to_string(),
@@ -702,7 +702,7 @@ async fn update_collection_grpc_test() {
     let versioned_collection = pin_update_collection_response.collection.unwrap();
 
     assert_ne!(versioned_collection.id, random_collection.id); // Versioned collection is deep clone with individual id
-    assert_eq!(versioned_collection.name, "Test Collection".to_string());
+    assert_eq!(versioned_collection.name, "Test-Collection".to_string());
     assert_eq!(
         versioned_collection.description,
         "Collection updated with version 1.2.3.".to_string()
@@ -729,7 +729,7 @@ async fn update_collection_grpc_test() {
     let update_versioned_collection_request = common::grpc_helpers::add_token(
         tonic::Request::new(UpdateCollectionRequest {
             collection_id: versioned_collection.id.to_string(),
-            name: "Test Collection".to_string(),
+            name: "Test-Collection".to_string(),
             description: "Versioned collection updated without version.".to_string(),
             labels: vec![KeyValue {
                 key: "is_versioned".to_string(),
@@ -752,7 +752,7 @@ async fn update_collection_grpc_test() {
     let update_versioned_collection_request = common::grpc_helpers::add_token(
         tonic::Request::new(UpdateCollectionRequest {
             collection_id: versioned_collection.id.to_string(),
-            name: "Test Collection".to_string(),
+            name: "Test-Collection".to_string(),
             description: "Versioned collection updated without version.".to_string(),
             labels: vec![KeyValue {
                 key: "is_versioned".to_string(),
@@ -803,7 +803,7 @@ async fn pin_collection_grpc_test() {
     // Create and get collection
     let create_collection_request = common::grpc_helpers::add_token(
         tonic::Request::new(CreateNewCollectionRequest {
-            name: "pin_collection_grpc_test()".to_string(),
+            name: "pin_collection_grpc_test_collection".to_string(),
             description: "Some description.".to_string(),
             project_id: random_project.id.to_string(),
             labels: vec![],

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -835,7 +835,7 @@ fn get_object_test() {
 
     // Get all objects
     let get_request = GetObjectByIdRequest {
-        collection_id: random_collection.id,
+        collection_id: random_collection.id.to_string(),
         object_id: new_obj.to_string(),
         with_url: false,
     };
@@ -846,7 +846,12 @@ fn get_object_test() {
     assert_eq!(get_obj.object.unwrap().id, new_obj);
 
     let get_obj_internal = db
-        .get_object_by_id(&uuid::Uuid::parse_str(&new_obj).unwrap())
+        .get_object_by_id(
+            &uuid::Uuid::parse_str(&new_obj).unwrap(),
+            &uuid::Uuid::parse_str(&random_collection.id.to_string()).unwrap(),
+        )
+        .unwrap()
+        .object
         .unwrap();
 
     assert_eq!(get_obj_internal.id.to_string(), new_obj);
@@ -1142,7 +1147,7 @@ fn delete_multiple_objects_test() {
 
     // Check random_collection objects
     let get_obj = GetObjectsRequest {
-        collection_id: source_collection.id,
+        collection_id: source_collection.id.to_string(),
         page_request: None,
         label_id_filter: None,
         with_url: false,
@@ -1155,18 +1160,14 @@ fn delete_multiple_objects_test() {
     // - obj_3_rev_0: moved writeable to random_collection2
     assert_eq!(resp.len(), 0);
 
-    let obj_1_rev_0_check = db
-        .get_object_by_id(&uuid::Uuid::parse_str(rnd_obj_1_rev_0.id.as_str()).unwrap())
-        .unwrap();
-    let obj_1_rev_1_check = db
-        .get_object_by_id(&uuid::Uuid::parse_str(rnd_obj_1_rev_1.id.as_str()).unwrap())
-        .unwrap();
-    let obj_2_rev_0_check = db
-        .get_object_by_id(&uuid::Uuid::parse_str(rnd_obj_2_rev_0.id.as_str()).unwrap())
-        .unwrap();
-    let obj_3_rev_0_check = db
-        .get_object_by_id(&uuid::Uuid::parse_str(rnd_obj_3_rev_0.id.as_str()).unwrap())
-        .unwrap();
+    let obj_1_rev_0_check =
+        common::functions::get_raw_db_object_by_id(&rnd_obj_1_rev_0.id.to_string());
+    let obj_1_rev_1_check =
+        common::functions::get_raw_db_object_by_id(&rnd_obj_1_rev_1.id.to_string());
+    let obj_2_rev_0_check =
+        common::functions::get_raw_db_object_by_id(&rnd_obj_2_rev_0.id.to_string());
+    let obj_3_rev_0_check =
+        common::functions::get_raw_db_object_by_id(&rnd_obj_3_rev_0.id.to_string());
 
     assert_eq!(obj_1_rev_0_check.object_status, ObjectStatus::AVAILABLE); // Read-only available in collection2
     assert_eq!(obj_1_rev_1_check.object_status, ObjectStatus::AVAILABLE); // Revision 1 is still read-only in collection2

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -690,7 +690,6 @@ fn delete_object_test() {
     assert_eq!(raw_db_object.object_status, ObjectStatus::TRASH);
 }
 
-/*
 #[test]
 #[ignore]
 #[serial(db)]
@@ -742,7 +741,6 @@ fn get_objects_test() {
 
     assert_eq!(get_response.len(), 64);
 }
-*/
 
 #[test]
 #[ignore]
@@ -964,7 +962,7 @@ fn clone_object_test() {
 
     let cloned = resp.object.unwrap();
 
-    assert!(cloned.id != update_2.id);
+    assert_ne!(cloned.id, update_2.id);
     assert_eq!(cloned.rev_number, 0);
     println!("{:#?}", cloned.id);
     println!("{:#?}", cloned.origin.clone().unwrap().id);

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -732,7 +732,7 @@ fn delete_object_references_test() {
         auto_update: true,
         sub_path: "".to_string(),
     })
-        .unwrap();
+    .unwrap();
 
     // Delete target collection reference
     db.delete_object(
@@ -744,13 +744,12 @@ fn delete_object_references_test() {
         },
         creator,
     )
-        .unwrap();
+    .unwrap();
 
     let undeleted = get_object(source_collection.id.to_string(), new_obj.id.to_string());
 
     assert_ne!(undeleted.filename, "DELETED".to_string())
 }
-
 
 #[test]
 #[ignore]

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -594,7 +594,7 @@ fn delete_object_test() {
         force: false,
     };
 
-    let resp = db.delete_object(delreq.clone(), creator);
+    let resp = db.delete_object(delreq, creator);
 
     assert!(resp.is_ok());
 
@@ -676,7 +676,7 @@ fn delete_object_test() {
     delreq.object_id = staging_finished.clone().object.unwrap().id;
 
     //println!("\nAbout to delete all revisions with the revision 0 id of an object.");
-    let _resp = db.delete_object(delreq.clone(), creator).unwrap();
+    let _resp = db.delete_object(delreq, creator).unwrap();
 
     // Revision Should also be deleted
     let raw_db_object = get_object_status_raw(&staging_finished.object.unwrap().id);
@@ -738,7 +738,7 @@ fn delete_object_references_test() {
     db.delete_object(
         DeleteObjectRequest {
             object_id: new_obj.id.to_string(),
-            collection_id: target_collection.id.to_string(),
+            collection_id: target_collection.id,
             with_revisions: false,
             force: false,
         },
@@ -746,7 +746,7 @@ fn delete_object_references_test() {
     )
     .unwrap();
 
-    let undeleted = get_object(source_collection.id.to_string(), new_obj.id.to_string());
+    let undeleted = get_object(source_collection.id, new_obj.id);
 
     assert_ne!(undeleted.filename, "DELETED".to_string())
 }
@@ -1132,7 +1132,7 @@ fn delete_multiple_objects_test() {
     ];
 
     let del_req = DeleteObjectsRequest {
-        object_ids: ids.clone(),
+        object_ids: ids,
         collection_id: source_collection.id.to_string(),
         with_revisions: true,
         force: false,
@@ -1142,7 +1142,7 @@ fn delete_multiple_objects_test() {
 
     // Check random_collection objects
     let get_obj = GetObjectsRequest {
-        collection_id: source_collection.id.to_string(),
+        collection_id: source_collection.id,
         page_request: None,
         label_id_filter: None,
         with_url: false,
@@ -1179,7 +1179,7 @@ fn delete_multiple_objects_test() {
 
     // Check random_collection2 objects
     let get_obj = GetObjectsRequest {
-        collection_id: target_collection.id.to_string(),
+        collection_id: target_collection.id,
         page_request: None,
         label_id_filter: None,
         with_url: false,

--- a/tests/e1_object_tests.rs
+++ b/tests/e1_object_tests.rs
@@ -3,7 +3,7 @@ mod common;
 use crate::common::functions::{get_object_status_raw, TCreateCollection};
 use aruna_rust_api::api::internal::v1::Location;
 use aruna_rust_api::api::storage::models::v1::{
-    DataClass, EndpointType, Hash as DbHash, Hashalgorithm, KeyValue, Version,
+    DataClass, EndpointType, Hash as DbHash, Hashalgorithm, KeyValue, PageRequest, Version,
 };
 use aruna_rust_api::api::storage::services::v1::{
     CloneObjectRequest, CreateNewCollectionRequest, CreateObjectReferenceRequest,
@@ -66,8 +66,8 @@ fn create_object_test() {
 
     // Create Collection
     let create_collection_request = CreateNewCollectionRequest {
-        name: "Object creation test project collection".to_string(),
-        description: "Test collection used in object creation test.".to_string(),
+        name: "create_object_test_collection".to_string(),
+        description: "Test collection used in create_object_test().".to_string(),
         label_ontology: None,
         project_id: project_id.to_string(),
         labels: vec![],
@@ -644,7 +644,6 @@ fn delete_object_test() {
         .update_object(&updatereq, &None, &creator, uuid::Uuid::default(), new_id)
         .unwrap();
 
-    println!("Finish object update for revision 1 before deletion.");
     let staging_finished = db
         .finish_object_staging(
             &FinishObjectStagingRequest {

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -2247,8 +2247,6 @@ async fn clone_object_grpc_test() {
         collection_id: source_collection.id.to_string(),
         new_name: "updated.object".to_string(),
         content_len: 1234,
-        num_labels: 0,
-        num_hooks: 0,
         ..Default::default()
     });
 
@@ -2302,8 +2300,6 @@ async fn clone_object_grpc_test() {
         collection_id: target_collection.id.to_string(),
         new_name: "clone.update".to_string(),
         content_len: 123456,
-        num_labels: 0,
-        num_hooks: 0,
         ..Default::default()
     });
 
@@ -2660,8 +2656,6 @@ async fn delete_object_grpc_test() {
         collection_id: random_collection.id.to_string(),
         new_name: "rev1.object".to_string(),
         content_len: 1234,
-        num_labels: 0,
-        num_hooks: 0,
         ..Default::default()
     });
 
@@ -2735,8 +2729,6 @@ async fn delete_object_revisions_grpc_test() {
         collection_id: random_collection.id.to_string(),
         new_name: "rev1.object".to_string(),
         content_len: 1234,
-        num_labels: 0,
-        num_hooks: 0,
         ..Default::default()
     };
     let rev_1_object = common::functions::update_object(&update_meta);
@@ -2797,8 +2789,6 @@ async fn delete_object_revisions_grpc_test() {
         collection_id: random_collection.id.to_string(),
         new_name: "random_update.01".to_string(),
         content_len: 123,
-        num_labels: 0,
-        num_hooks: 0,
         ..Default::default()
     };
     let random_object_rev_1 = common::functions::update_object(&update_meta);

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -628,8 +628,8 @@ async fn update_staging_object_grpc_test() {
         for new_label in rev_0_staging_object_updated.labels.clone() {
             if old_label == new_label {
                 continue 'outer;
-            } else if old_label.key == "app.aruna-storage.org/new_path".to_string()
-                && new_label.key == "app.aruna-storage.org/new_path".to_string()
+            } else if old_label.key == *"app.aruna-storage.org/new_path"
+                && new_label.key == *"app.aruna-storage.org/new_path"
             {
                 continue 'outer;
             }

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -3211,7 +3211,7 @@ async fn delete_multiple_objects_grpc_test() {
                 let updated_object = common::functions::update_object(&TCreateUpdate {
                     original_object: source_object.clone(),
                     collection_id: random_collection.id.to_string(),
-                    new_name: format!("object-update.{}", update_num).to_string(),
+                    new_name: format!("update.{}.{}", source_object.id, update_num).to_string(),
                     content_len: rng.gen_range(1234..123456),
                     ..Default::default()
                 });

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -630,10 +630,21 @@ async fn update_staging_object_grpc_test() {
     assert_eq!(rev_0_staging_object.hash, rev_0_staging_object_updated.hash);
 
     // Labels/Hooks should be the same as they were not updated
-    assert_eq!(
-        rev_0_staging_object.labels,
-        rev_0_staging_object_updated.labels
-    );
+    // except internal ...
+
+    'outer: for old_label in rev_0_staging_object.labels {
+        for new_label in rev_0_staging_object_updated.labels.clone() {
+            if old_label == new_label {
+                continue 'outer;
+            } else if old_label.key == "app.aruna-storage.org/new_path".to_string()
+                && new_label.key == "app.aruna-storage.org/new_path".to_string()
+            {
+                continue 'outer;
+            }
+        }
+        panic!("No corresponding label found for old: {:#?}", old_label)
+    }
+
     assert_eq!(
         rev_0_staging_object.hooks,
         rev_0_staging_object_updated.hooks

--- a/tests/e2_objects_grpc_test.rs
+++ b/tests/e2_objects_grpc_test.rs
@@ -72,18 +72,8 @@ async fn create_objects_grpc_test() {
     // Create random collection
     let random_collection = common::functions::create_collection(TCreateCollection {
         project_id: random_project.id.to_string(),
-        num_labels: 0,
-        num_hooks: 0,
-        col_override: Some(CreateNewCollectionRequest {
-            name: "create_objects_grpc_test() Collection".to_string(),
-            description: "Lorem Ipsum Dolor".to_string(),
-            project_id: random_project.id.to_string(),
-            labels: vec![],
-            hooks: vec![],
-            label_ontology: None,
-            dataclass: DataClass::Private as i32,
-        }),
         creator_id: Some(user_id.to_string()),
+        ..Default::default()
     });
 
     // Init object in non-existing collection --> Error

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -433,10 +433,10 @@ async fn get_object_path_grpc_test() {
         "//path/".to_string(),       // Empty path parts are not allowed
         "//path//".to_string(),      // Empty path parts are not allowed
         "path//path".to_string(),    // Empty path parts are not allowed
-        "$%&/path/".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no special characters
-        "custom\\path/".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no backslashes
-        "some path".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no whitespace
-        "some|path".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no pipe
+        "$%&/path/".to_string(),     // Only ^(/?[\w~\-.]+)*/?$ allowed; no special characters
+        "custom\\path/".to_string(), // Only ^(/?[\w~\-.]+)*/?$ allowed; no backslashes
+        "some path".to_string(),     // Only ^(/?[\w~\-.]+)*/?$ allowed; no whitespace
+        "some|path".to_string(),     // Only ^(/?[\w~\-.]+)*/?$ allowed; no pipe
     ]
     .iter()
     {

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -227,10 +227,8 @@ async fn create_additional_object_path_grpc_test() {
     // Fast track collection creation
     let collection_meta = TCreateCollection {
         project_id: random_project.id.to_string(),
-        num_labels: 0,
-        num_hooks: 0,
-        col_override: None,
         creator_id: Some(user_id.clone()),
+        ..Default::default()
     };
     let random_collection = common::functions::create_collection(collection_meta.clone());
 

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -433,10 +433,10 @@ async fn get_object_path_grpc_test() {
         "//path/".to_string(),       // Empty path parts are not allowed
         "//path//".to_string(),      // Empty path parts are not allowed
         "path//path".to_string(),    // Empty path parts are not allowed
-        "$%&/path/".to_string(),     // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no special characters
+        "$%&/path/".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no special characters
         "custom\\path/".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no backslashes
-        "some path".to_string(),     // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no whitespace
-        "some|path".to_string(),     // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no pipe
+        "some path".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no whitespace
+        "some|path".to_string(), // Only ^/?([\w~\-.]+/?[\w~\-.]*)+/?$ allowed; no pipe
     ]
     .iter()
     {
@@ -458,8 +458,7 @@ async fn get_object_path_grpc_test() {
     }
 
     // Vector to save created paths for easier validation (already includes object default path)
-    let mut fq_valid_paths =
-        vec![format!("{static_path_part}/{}", random_object.filename).to_string()];
+    let mut fq_valid_paths = vec![format!("{static_path_part}/{}", random_object.filename)];
 
     // Requests with valid paths in different formats
     for valid_path in vec![
@@ -481,9 +480,7 @@ async fn get_object_path_grpc_test() {
             tonic::Request::new(inner_create_path_request.clone()),
             common::oidc::ADMINTOKEN,
         );
-        let create_path_response = object_service
-            .create_object_path(create_path_request)
-            .await;
+        let create_path_response = object_service.create_object_path(create_path_request).await;
 
         if create_path_response.is_err() {
             // Hint in the terminal output which path failed the test.

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -709,7 +709,6 @@ async fn get_object_paths_grpc_test() {
         let set_visibility_request = common::grpc_helpers::add_token(
             tonic::Request::new(SetObjectPathVisibilityRequest {
                 collection_id: random_collection.id.to_string(),
-                object_id: "".to_string(), // No use. Deprecated with 1.0.0-rc.3
                 path: default_path.to_string(),
                 visibility: false,
             }),
@@ -924,7 +923,6 @@ async fn set_object_path_visibility_grpc_test() {
     // Set visibility of some paths to inactive
     let mut inner_set_visibility_request = SetObjectPathVisibilityRequest {
         collection_id: random_collection.id.to_string(),
-        object_id: random_object.id.to_string(),
         path: "".to_string(),
         visibility: false,
     };

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -1426,7 +1426,7 @@ async fn get_object_by_path_grpc_test() {
             .object[0]
             .clone();
 
-        assert_eq!(proto_object, rev_1_object); // Objects should be equal.
+        assert_eq!(proto_object, rev_1_object); // Objects should be equal and always latest revision
     }
 
     // Get all object revisions through available paths

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -506,11 +506,6 @@ async fn create_object_path_with_reference_grpc_test() {
         .await
         .unwrap();
 
-    dbg!(common::functions::get_object(
-        source_collection.id.to_string(),
-        random_object.id.to_string()
-    ));
-
     // Create object reference with custom subpath in target collection
     inner_create_reference_request.sub_path = "custom/".to_string();
     let custom_path_reference_request = common::grpc_helpers::add_token(

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -3,15 +3,17 @@ use crate::common::grpc_helpers::get_token_user_id;
 
 use aruna_rust_api::api::storage::models::v1::{DataClass, Hash, Hashalgorithm, Permission};
 use aruna_rust_api::api::storage::services::v1::object_service_server::ObjectService;
-use aruna_rust_api::api::storage::services::v1::{FinishObjectStagingRequest, GetObjectByIdRequest, InitializeNewObjectRequest, StageObject};
+use aruna_rust_api::api::storage::services::v1::{
+    FinishObjectStagingRequest, GetObjectByIdRequest, InitializeNewObjectRequest, StageObject,
+};
 use aruna_server::config::ArunaServerConfig;
 use aruna_server::database;
 use aruna_server::server::services::authz::Authz;
 use aruna_server::server::services::object::ObjectServiceImpl;
 
+use aruna_server::database::crud::object::get_object;
 use serial_test::serial;
 use std::sync::Arc;
-use aruna_server::database::crud::object::get_object;
 
 mod common;
 
@@ -50,7 +52,7 @@ async fn create_object_with_path_grpc_test() {
         user_id.as_str(),
         common::oidc::ADMINTOKEN,
     )
-        .await;
+    .await;
     assert_eq!(add_perm.permission, Permission::None as i32);
 
     // Fast track collection creation
@@ -131,8 +133,7 @@ async fn create_object_with_path_grpc_test() {
             collection_id: init_object_response.collection_id.to_string(),
             hash: Some(Hash {
                 alg: Hashalgorithm::Sha256 as i32,
-                hash:
-                "4ec2d656985e3d823b81cc2cd9b56ec27ab1303cfebaf5f95c37d2fe1661a779"
+                hash: "4ec2d656985e3d823b81cc2cd9b56ec27ab1303cfebaf5f95c37d2fe1661a779"
                     .to_string(),
             }),
             no_upload: false,
@@ -168,7 +169,9 @@ async fn create_object_with_path_grpc_test() {
 
     assert_eq!(custom_object.id, init_object_response.object_id);
     assert_eq!(custom_object_with_url.paths.len(), 1); // Only empty default path
-    assert!(custom_object_with_url.paths.contains(&"/my/little/pony".to_string()));
+    assert!(custom_object_with_url
+        .paths
+        .contains(&"/my/little/pony".to_string()));
     assert!(custom_object_with_url.url.is_empty());
 }
 

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -447,7 +447,7 @@ async fn create_object_path_with_reference_grpc_test() {
     assert_eq!(target_collection_paths.len(), 1); // Only default subpath of object
     assert_eq!(
         target_collection_paths.first().unwrap().path,
-        format!("{static_path_part}/{}", random_object.filename).to_string()
+        format!("{static_path_part}/{}", random_object.filename)
     );
 
     // Update object and create static reference on revision 0 in same collection with default subpath
@@ -488,7 +488,7 @@ async fn create_object_path_with_reference_grpc_test() {
     assert_eq!(target_collection_paths.len(), 1); // Only default subpath of object
     assert_eq!(
         target_collection_paths.first().unwrap().path,
-        format!("{static_path_part}/{}", random_object.filename).to_string()
+        format!("{static_path_part}/{}", random_object.filename)
     );
 
     // Remove object from target collection which includes removal of all its paths
@@ -540,7 +540,7 @@ async fn create_object_path_with_reference_grpc_test() {
     assert_eq!(target_collection_paths.len(), 1); // Only custom subpath of object
     assert_eq!(
         target_collection_paths.first().unwrap().path,
-        format!("{static_path_part}/custom/{}", random_object.filename).to_string()
+        format!("{static_path_part}/custom/{}", random_object.filename)
     );
 }
 
@@ -684,12 +684,10 @@ async fn get_object_path_grpc_test() {
             } else {
                 format!("{static_path_part}{valid_path}/{}", random_object.filename).to_string()
             }
+        } else if valid_path.ends_with('/') {
+            format!("{static_path_part}/{valid_path}{}", random_object.filename).to_string()
         } else {
-            if valid_path.ends_with('/') {
-                format!("{static_path_part}/{valid_path}{}", random_object.filename).to_string()
-            } else {
-                format!("{static_path_part}/{valid_path}/{}", random_object.filename).to_string()
-            }
+            format!("{static_path_part}/{valid_path}/{}", random_object.filename).to_string()
         };
 
         assert_eq!(created_path.path, fq_path);

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -5,7 +5,7 @@ use aruna_rust_api::api::storage::models::v1::{DataClass, Hash, Hashalgorithm, P
 use aruna_rust_api::api::storage::services::v1::object_service_server::ObjectService;
 use aruna_rust_api::api::storage::services::v1::{
     CreateObjectPathRequest, FinishObjectStagingRequest, GetObjectByIdRequest,
-    GetObjectPathRequest, GetObjectPathsRequest, InitializeNewObjectRequest,
+    GetObjectPathRequest, GetObjectPathsRequest, InitializeNewObjectRequest, Path,
     SetObjectPathVisibilityRequest, StageObject,
 };
 use aruna_server::config::ArunaServerConfig;
@@ -524,11 +524,231 @@ async fn get_object_paths_grpc_test() {
 /// 1) Creating an object with the default subpath
 /// 2) Creating some additional paths for the same object
 /// 3) Modify visibility of some paths
+/// 4) Get all paths of object
+/// 5) Get all active paths of object
 #[ignore]
 #[tokio::test]
 #[serial(db)]
 async fn set_object_path_visibility_grpc_test() {
-    todo!()
+    // Init database connection
+    let db = Arc::new(database::connection::Database::new(
+        "postgres://root:test123@localhost:26257/test",
+    ));
+    let authz = Arc::new(Authz::new(db.clone()).await);
+
+    // Read test config relative to binary
+    let config = ArunaServerConfig::new();
+
+    // Initialize instance default data proxy endpoint
+    let default_endpoint = db
+        .clone()
+        .init_default_endpoint(config.config.default_endpoint)
+        .unwrap();
+
+    // Init object service
+    let object_service = ObjectServiceImpl::new(db.clone(), authz, default_endpoint).await;
+
+    // Fast track project creation
+    let random_project = common::functions::create_project(None);
+
+    // Fast track adding user to project
+    let user_id = get_token_user_id(common::oidc::REGULARTOKEN).await;
+    let add_perm = common::grpc_helpers::add_project_permission(
+        random_project.id.as_str(),
+        user_id.as_str(),
+        common::oidc::ADMINTOKEN,
+    )
+    .await;
+    assert_eq!(add_perm.permission, Permission::None as i32);
+
+    // Fast track collection creation
+    let collection_meta = TCreateCollection {
+        project_id: random_project.id.to_string(),
+        num_labels: 0,
+        num_hooks: 0,
+        col_override: None,
+        creator_id: Some(user_id.clone()),
+    };
+    let random_collection = common::functions::create_collection(collection_meta.clone());
+
+    // Create random object with default subpath
+    let object_meta = TCreateObject {
+        creator_id: Some(user_id.clone()),
+        collection_id: random_collection.id.to_string(),
+        num_labels: 0,
+        num_hooks: 0,
+        ..Default::default()
+    };
+    let random_object = common::functions::create_object(&object_meta);
+
+    let static_path_part = format!("/{}/{}", random_project.name, random_collection.name);
+
+    let mut inner_create_path_request = CreateObjectPathRequest {
+        collection_id: random_collection.id.to_string(),
+        object_id: random_object.id.to_string(),
+        sub_path: "".to_string(),
+    };
+
+    for valid_path in vec![
+        "path_01".to_string(),
+        "path_02".to_string(),
+        "path_03".to_string(),
+        "path_04".to_string(),
+        "path_05".to_string(),
+    ]
+    .iter()
+    {
+        inner_create_path_request.sub_path = valid_path.to_string();
+        let create_path_request = common::grpc_helpers::add_token(
+            tonic::Request::new(inner_create_path_request.clone()),
+            common::oidc::ADMINTOKEN,
+        );
+        let create_path_response = object_service
+            .create_object_path(create_path_request)
+            .await
+            .unwrap()
+            .into_inner();
+
+        let fq_path =
+            format!("{static_path_part}/{valid_path}/{}", random_object.filename).to_string();
+        assert_eq!(create_path_response.path.unwrap().path, fq_path);
+    }
+
+    // Set visibility of some paths to inactive
+    let mut inner_set_visibility_request = SetObjectPathVisibilityRequest {
+        collection_id: random_collection.id.to_string(),
+        object_id: random_object.id.to_string(),
+        path: "".to_string(),
+        visibility: false,
+    };
+
+    for set_visibility_path in vec![
+        "path_02".to_string(),
+        "path_03".to_string(),
+        "path_04".to_string(),
+    ]
+    .iter()
+    {
+        inner_set_visibility_request.path = set_visibility_path.to_string();
+
+        let set_visibility_request = common::grpc_helpers::add_token(
+            tonic::Request::new(inner_set_visibility_request.clone()),
+            common::oidc::ADMINTOKEN,
+        );
+
+        let set_visibility_response = object_service
+            .set_object_path_visibility(set_visibility_request)
+            .await
+            .unwrap()
+            .into_inner();
+
+        let inactive_path = set_visibility_response.path.unwrap();
+        let fq_path = format!(
+            "{static_path_part}/{set_visibility_path}/{}",
+            random_object.filename
+        );
+
+        assert_eq!(inactive_path.path, fq_path);
+        assert_eq!(inactive_path.visibility, false);
+    }
+
+    // Set visibility of one path to active again
+    let fq_path = format!("{static_path_part}/path_03/{}", random_object.filename);
+    inner_set_visibility_request.path = fq_path.to_string();
+    inner_set_visibility_request.visibility = true;
+
+    let set_visibility_request = common::grpc_helpers::add_token(
+        tonic::Request::new(inner_set_visibility_request.clone()),
+        common::oidc::ADMINTOKEN,
+    );
+
+    let set_visibility_response = object_service
+        .set_object_path_visibility(set_visibility_request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let inactive_path = set_visibility_response.path.unwrap();
+    let fq_path = format!(
+        "{static_path_part}/{}/{}",
+        "path_03".to_string(),
+        random_object.filename
+    );
+
+    assert_eq!(inactive_path.path, fq_path);
+    assert_eq!(inactive_path.visibility, false);
+
+    // Get all active paths of object
+    let mut inner_get_paths_request = GetObjectPathsRequest {
+        collection_id: random_collection.id.to_string(),
+        include_inactive: false,
+    };
+
+    let get_paths_request = common::grpc_helpers::add_token(
+        tonic::Request::new(inner_get_paths_request.clone()),
+        common::oidc::ADMINTOKEN,
+    );
+
+    let get_paths_response = object_service
+        .get_object_paths(get_paths_request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let active_paths = get_paths_response.object_paths;
+    assert_eq!(active_paths.len(), 3); // Contains only the three active paths
+
+    for active_path in vec![
+        "path_01".to_string(),
+        "path_03".to_string(),
+        "path_05".to_string(),
+    ]
+    .iter()
+    {
+        let proto_path = Path {
+            path: format!(
+                "{static_path_part}/{active_path}/{}",
+                random_object.filename
+            )
+            .to_string(),
+            visibility: true,
+        };
+
+        assert!(active_paths.contains(&proto_path));
+    }
+
+    // Get all paths of object and validate visibility
+    inner_get_paths_request.include_inactive = true;
+    let get_paths_request = common::grpc_helpers::add_token(
+        tonic::Request::new(inner_get_paths_request.clone()),
+        common::oidc::ADMINTOKEN,
+    );
+
+    let get_paths_response = object_service
+        .get_object_paths(get_paths_request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let all_paths = get_paths_response.object_paths;
+    for path in vec!["path_01", "path_02", "path_03", "path_04", "path_05"].iter() {
+        let mut proto_path = Path {
+            path: format!(
+                "{static_path_part}/{path}/{}",
+                random_object.filename
+            )
+            .to_string(),
+            visibility: true,
+        };
+
+        proto_path.visibility = match *path {
+            "path_01" | "path_03" | "path_05" => true,
+            "path_02" | "path_04" => false,
+            _ => panic!("Received sub path which should not exist."),
+        };
+
+        assert!(all_paths.contains(&proto_path));
+    }
 }
 
 /// The individual steps of this test function contains:

--- a/tests/e3_object_path_grpc_tests.rs
+++ b/tests/e3_object_path_grpc_tests.rs
@@ -59,10 +59,8 @@ async fn create_object_with_path_grpc_test() {
     // Fast track collection creation
     let collection_meta = TCreateCollection {
         project_id: random_project.id.to_string(),
-        num_labels: 0,
-        num_hooks: 0,
-        col_override: None,
         creator_id: Some(user_id.clone()),
+        ..Default::default()
     };
     let random_collection = common::functions::create_collection(collection_meta.clone());
 
@@ -576,10 +574,8 @@ async fn get_object_paths_grpc_test() {
     // Fast track collection creation
     let collection_meta = TCreateCollection {
         project_id: random_project.id.to_string(),
-        num_labels: 0,
-        num_hooks: 0,
-        col_override: None,
         creator_id: Some(user_id.clone()),
+        ..Default::default()
     };
     let random_collection = common::functions::create_collection(collection_meta.clone());
 

--- a/tests/f_object_groups.rs
+++ b/tests/f_object_groups.rs
@@ -521,14 +521,14 @@ fn object_group_staging_object_test() {
         ..Default::default()
     });
 
-    let mut polluted_object_ids = vec![staging_object.id.clone()];
+    let mut polluted_object_ids = vec![staging_object.id];
     polluted_object_ids.append(&mut object_ids);
 
     // Try create object group with staging object in data objects
     let mut create_request = CreateObjectGroupRequest {
         name: "object_group_staging_object_test.fail".to_string(),
         description: "Created within object_group_staging_object_test().".to_string(),
-        collection_id: random_collection.id.to_string(),
+        collection_id: random_collection.id,
         object_ids: polluted_object_ids.clone(),
         meta_object_ids: vec![],
         labels: vec![],

--- a/tests/f_object_groups.rs
+++ b/tests/f_object_groups.rs
@@ -403,6 +403,7 @@ fn delete_object_group_test() {
     db.delete_object_group(DeleteObjectGroupRequest {
         group_id: object_group_rev_0.id.to_string(),
         collection_id: random_collection.id.to_string(),
+        with_revisions: false,
     })
     .unwrap();
 
@@ -438,6 +439,7 @@ fn delete_object_group_test() {
     db.delete_object_group(DeleteObjectGroupRequest {
         group_id: object_group_rev_1.id.to_string(),
         collection_id: random_collection.id.to_string(),
+        with_revisions: false,
     })
     .unwrap();
 

--- a/tests/sources/up.sql
+++ b/tests/sources/up.sql
@@ -61,7 +61,7 @@ CREATE TABLE external_user_ids (
 -- Table with projects which acts as logical space for collections
 CREATE TABLE projects (
     id UUID PRIMARY KEY,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL UNIQUE,
     description TEXT NOT NULL DEFAULT '',
     flag INT NOT NULL DEFAULT 0,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -105,7 +105,8 @@ CREATE TABLE collections (
     dataclass DATACLASS,
     project_id UUID NOT NULL,
     FOREIGN KEY (project_id) REFERENCES projects(id),
-    FOREIGN KEY (created_by) REFERENCES users(id)
+    FOREIGN KEY (created_by) REFERENCES users(id),
+    UNIQUE(name, project_id)
 );
 -- Table with the key-value pairs associated with specific collections
 CREATE TABLE collection_key_value (
@@ -141,7 +142,7 @@ CREATE TABLE objects (
     object_status OBJECT_STATUS NOT NULL DEFAULT 'INITIALIZING',
     dataclass DATACLASS NOT NULL DEFAULT 'PRIVATE',
     source_id UUID REFERENCES sources(id),
-    origin_id UUID,
+    origin_id UUID NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (created_by) REFERENCES users(id)
 );
@@ -281,6 +282,17 @@ CREATE TABLE notification_stream_groups (
     resource_id UUID NOT NULL,
     resource_type RESOURCES NOT NULL,
     notify_on_sub_resources BOOL NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE paths (
+    id UUID PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE, -- /project-name/collection-name/user-defined-path/lorem.txt
+    shared_revision_id UUID NOT NULL,
+    collection_id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    active BOOL NOT NULL DEFAULT FALSE,
+    FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+    UNIQUE (path)
 );
 /* ----- Materialized Views --------------------------------------- */
 -- Materialized view for the collections table

--- a/tests/sources/up.sql
+++ b/tests/sources/up.sql
@@ -106,7 +106,7 @@ CREATE TABLE collections (
     project_id UUID NOT NULL,
     FOREIGN KEY (project_id) REFERENCES projects(id),
     FOREIGN KEY (created_by) REFERENCES users(id),
-    UNIQUE(name, project_id)
+    UNIQUE(name, project_id, version_id)
 );
 -- Table with the key-value pairs associated with specific collections
 CREATE TABLE collection_key_value (

--- a/tests/sources/up.sql
+++ b/tests/sources/up.sql
@@ -228,8 +228,7 @@ CREATE TABLE collection_objects (
     reference_status REFERENCE_STATUS NOT NULL DEFAULT 'OK',
     FOREIGN KEY (object_id) REFERENCES objects(id),
     FOREIGN KEY (collection_id) REFERENCES collections(id),
-    -- Unique reference possible for static and auto_update parallel on same revision
-    CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id, auto_update)
+    CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id)
 );
 -- Join table between collections and object_groups
 CREATE TABLE collection_object_groups (


### PR DESCRIPTION
This adds all the changes since ArunaAPI version 1.0.0-rc.1.

## Changes 1.0.0-rc.1:

* Added dummy implementation of paths logic for objects as prerequisite for the upcoming S3 compatibility
* Convert origin_id to a mandatory field for an object

## Changes 1.0.0-rc.2:

* Implementation of paths logic for objects as prerequisite for the upcoming S3 compatibility
* Implemented tests for all the object path functionality 
* Hash can be added now to an object on creation with the `InitializeNewObjectRequest`
* Removed the type from the origin part of a returned object as it poses no added value for the user

## Changes 1.0.0-rc.4:

* Limit project/collection names to [RFC3986 unreserved characters](https://www.rfc-editor.org/rfc/rfc3986#section-2.3) for path compliance
* Rollback useless migration which allowed objects to have two references (one static and one auto updating) parallel in a collection
* Restrict creation of object references:
    * Staging objects cannot be referenced in other collections anymore
    * References with `auto_update == true` can only be created for the latest revision of an object
* ObjectGroups can be deleted completely with the new `with_revisions` parameter of the `DeleteObjectGroupRequest`
* Refactor `get_object` and `get_object_by_id` functions to respect permission boundaries on object fetching

## Changes 1.0.0-rc.5:

* Updated various dependencies to their latest version and fixed the breaking changes 
* Added dummy implementation for the new `InternalProxyNotifierService`

## Bugfixes/Refactor changes

* Lots of smaller bugs and refactors which were required before 1.0.0 release (Closes #64)
