### PR TITLE
Ignore deleted revisions in get_latest_obj(...)

### DIFF
--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -2535,7 +2535,12 @@ pub fn get_latest_obj(
         .first::<uuid::Uuid>(conn)?;
 
     let latest_object = objects
-        .filter(database::schema::objects::shared_revision_id.eq(shared_id))
+        .filter(
+            database::schema::objects::shared_revision_id
+                .eq(&shared_id)
+                .and(database::schema::objects::object_status.ne(&ObjectStatus::DELETED))
+                .and(database::schema::objects::object_status.ne(&ObjectStatus::TRASH)),
+        )
         .order_by(database::schema::objects::revision_number.desc())
         .first::<Object>(conn)?;
 

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -2021,7 +2021,7 @@ impl Database {
                 }
 
                 let (s3bucket, s3path) = request.path[5..]
-                    .split_once("/")
+                    .split_once('/')
                     .ok_or(ArunaError::InvalidRequest("Invalid path".to_string()))?;
 
                 let old_path = paths
@@ -2070,7 +2070,7 @@ impl Database {
                 }
 
                 let (s3bucket, s3path) = request.path[5..]
-                    .split_once("/")
+                    .split_once('/')
                     .ok_or(ArunaError::InvalidRequest("Invalid path".to_string()))?;
 
                 let get_path = paths

--- a/src/database/crud/user.rs
+++ b/src/database/crud/user.rs
@@ -281,7 +281,7 @@ impl Database {
             token: Some(Token {
                 id: api_token.id.to_string(),
                 name: api_token.name.unwrap_or_default(),
-                token_type: token_type as i32,
+                token_type,
                 created_at: Some(naivedatetime_to_prost_time(api_token.created_at)?),
                 expires_at: expires_at_time,
                 collection_id: option_to_string(api_token.collection_id).unwrap_or_default(),
@@ -350,7 +350,7 @@ impl Database {
                         .as_ref()
                         .unwrap_or(&"".to_string())
                         .to_string(),
-                    token_type: token_type as i32,
+                    token_type,
                     created_at: Some(naivedatetime_to_prost_time(api_token.created_at)?),
                     expires_at: expires_at_time,
                     collection_id: option_to_string(api_token.collection_id).unwrap_or_default(),


### PR DESCRIPTION
This fixes #67 as it introduces a filter for already deleted revisions on getting the latest object revision.