### PR TITLE
feat: Contention fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "simple_logger",
- "time 0.3.20",
+ "time 0.3.21",
  "tokio",
  "tokio-stream",
  "toml",
@@ -115,7 +115,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "byteorder"
@@ -285,16 +285,6 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -347,50 +337,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]
@@ -723,7 +669,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -779,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -993,12 +939,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1070,9 +1015,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1269,24 +1214,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -1305,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -1511,7 +1447,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1610,22 +1546,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1664,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1792,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -1894,14 +1830,13 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqsign"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f753b768a9d691395e7db3dc74452cc39a5da55293c3fa2241e2aeaf9d94028"
+checksum = "a16a222894949f891cdfcb0c2c63913a975689fa7f7162d01d85df7837506ab8"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.0",
- "bytes",
  "chrono",
  "form_urlencoded",
  "hex",
@@ -2009,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -2036,7 +1971,7 @@ dependencies = [
  "chrono",
  "rand",
  "serde",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -2095,12 +2030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2125,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2135,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -2154,13 +2083,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2242,7 +2171,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2295,7 +2224,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -2307,7 +2236,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.20",
+ "time 0.3.21",
  "windows-sys 0.42.0",
 ]
 
@@ -2377,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2406,15 +2335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,7 +2351,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2447,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -2461,15 +2381,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -2491,9 +2411,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2526,7 +2446,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2726,14 +2646,14 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
@@ -2781,12 +2701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,7 +2743,7 @@ checksum = "18d884370cccfad1f913e67c7362f9c00357844bc9f3cfce86faa2241cabd166"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2868,9 +2782,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2878,24 +2792,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "083abe15c5d88556b77bdf7aef403625be9e327ad37c62c4e4129af740168163"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2905,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2915,28 +2829,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2968,15 +2882,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/migrations/2022-12-02-110911_unique_user_permissions/down.sql
+++ b/migrations/2022-12-02-110911_unique_user_permissions/down.sql
@@ -6,4 +6,4 @@
 -- Warning:
 --   CASCADE drops all dependent objects without listing them, which can lead to inadvertent and difficult-to-recover losses.
 --   To avoid potential harm, it is recommended dropping objects individually in most cases.
-DROP INDEX unique_user_project_permission CASCADE;
+DROP INDEX unique_user_project_permission;

--- a/migrations/2023-02-13-113213_add_paths/down.sql
+++ b/migrations/2023-02-13-113213_add_paths/down.sql
@@ -1,4 +1,4 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE IF EXISTS paths;
-DROP INDEX uniqe_collection_name_project_id CASCADE;
-DROP INDEX unique_project_name CASCADE;
+DROP INDEX uniqe_collection_name_project_id;
+DROP INDEX unique_project_name;

--- a/migrations/2023-05-15-081831_indices/down.sql
+++ b/migrations/2023-05-15-081831_indices/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+CREATE INDEX objects_id_idx ON objects (shared_revision_id, revision_number);
+DROP INDEX objects_shared_rev_idx ON objects;
+DROP INDEX objects_shared_single_idx ON objects;
+DROP INDEX hashes_objects_idx ON hashes;
+DROP INDEX object_key_value_objects_idx ON object_key_value;
+DROP INDEX collection_objects_collection_idx ON collection_objects;
+DROP INDEX collection_objects_objects_idx ON collection_objects;

--- a/migrations/2023-05-15-081831_indices/up.sql
+++ b/migrations/2023-05-15-081831_indices/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+
+DROP INDEX objects_id_idx ON objects;
+CREATE INDEX objects_shared_rev_idx ON objects (shared_revision_id, revision_number);
+CREATE INDEX objects_shared_single_idx ON objects (shared_revision_id);
+CREATE INDEX hashes_objects_idx ON hashes (object_id);
+CREATE INDEX object_key_value_objects_idx ON object_key_value (object_id);
+CREATE INDEX collection_objects_collection_idx ON collection_objects (collection_id);
+CREATE INDEX collection_objects_objects_idx ON collection_objects (object_id);

--- a/src/database/crud/authz.rs
+++ b/src/database/crud/authz.rs
@@ -366,6 +366,7 @@ impl Database {
                     thread::sleep(time::Duration::from_millis(backoff as u64));
                     backoff = i32::pow(backoff, 2);
                     if backoff > 100000 {
+                        log::warn!("Backoff reached for auth!");
                         break;
                     }
                 }

--- a/src/database/crud/authz.rs
+++ b/src/database/crud/authz.rs
@@ -1,3 +1,6 @@
+use std::thread;
+use std::time;
+
 use crate::database::connection::Database;
 use crate::database::models::auth::{ApiToken, PubKey, PubKeyInsert, User, UserPermission};
 use crate::database::models::enums::{Resources, UserRights};
@@ -132,116 +135,128 @@ impl Database {
         use crate::database::schema::user_permissions::dsl::*;
         use diesel::result::Error as dError;
 
-        let (creator_uid, api_token) =
-            self.pg_connection
-                .get()?
-                .transaction::<(Option<diesel_ulid::DieselUlid>, ApiToken), dError, _>(|conn| {
-                    // Get the API token, if this errors -> no corresponding database token object could be found
-                    let api_token = api_tokens
-                        .filter(crate::database::schema::api_tokens::id.eq(ctx_token))
-                        .first::<ApiToken>(conn)?;
+        let mut backoff = 10;
+        let mut transaction_result: Result<(Option<diesel_ulid::DieselUlid>, ApiToken), dError>;
 
-                    // Case 1:
-                    // This is checked first because all other checks can be omitted if this succeeds
-                    // Check if Token is "personal" and if the request is admin scoped
-                    // Check if the user has admin permissions and return
+        // Insert all defined objects into the database
 
-                    if api_token.collection_id.is_none() && api_token.project_id.is_none() {
-                        let admin_user_perm = sql_query(
-                            "SELECT uperm.id, uperm.user_id, uperm.user_right, uperm.project_id 
+        loop {
+            transaction_result =
+                self.pg_connection
+                    .get()?
+                    .transaction::<(Option<diesel_ulid::DieselUlid>, ApiToken), dError, _>(
+                        |conn| {
+                            // Get the API token, if this errors -> no corresponding database token object could be found
+                            let api_token = api_tokens
+                                .filter(crate::database::schema::api_tokens::id.eq(ctx_token))
+                                .first::<ApiToken>(conn)?;
+
+                            // Case 1:
+                            // This is checked first because all other checks can be omitted if this succeeds
+                            // Check if Token is "personal" and if the request is admin scoped
+                            // Check if the user has admin permissions and return
+
+                            if api_token.collection_id.is_none() && api_token.project_id.is_none() {
+                                let admin_user_perm = sql_query(
+                        "SELECT uperm.id, uperm.user_id, uperm.user_right, uperm.project_id 
                                FROM user_permissions AS uperm 
                                JOIN projects AS p 
                                ON p.id = uperm.project_id 
                                WHERE uperm.user_id = $1
                                AND p.flag & 1 = 1
                                LIMIT 1",
-                        )
-                        .bind::<Uuid, _>(api_token.creator_user_id)
-                        .get_result::<UserPermission>(conn)
-                        .optional()?;
+                    )
+                    .bind::<Uuid, _>(api_token.creator_user_id)
+                    .get_result::<UserPermission>(conn)
+                    .optional()?;
 
-                        // If an associated admin_user_perm is found, this can return a new context
-                        // for the admin scope
-                        if admin_user_perm.is_some() {
-                            return Ok((Some(api_token.creator_user_id), api_token));
-                        }
-                    }
-
-                    // Case 2:
-                    // The request is a "personal" scope
-                    // This can immediately return the user_id if the token is also personal scoped
-                    // Mostly used to modify tokens
-                    if req_ctx.personal {
-                        if api_token.project_id.is_none() && api_token.collection_id.is_none() {
-                            return Ok((Some(api_token.creator_user_id), api_token));
-                        } else {
-                            return Err(dError::NotFound);
-                        }
-                    }
-
-                    // If the requested context / scope is of type COLLECTION
-                    if req_ctx.resource_type == Resources::COLLECTION {
-                        // Case 3:
-                        // If api_token.collection_id == context_collection_id
-                        // And user_right != None && api_token.collection_id != None && context_collection_id != None
-                        // This will return Some(Context) otherwise this will return None
-                        if api_token.collection_id.is_some() {
-                            let collection_ctx = option_uuid_helper(
-                                api_token.collection_id,
-                                Some(req_ctx.resource_id),
-                                Resources::COLLECTION,
-                                req_ctx.user_right,
-                                api_token.user_right,
-                            );
-
-                            // If apitoken.collection_id == context_collection_id
-                            // We can return early here -> The ApiToken is "scoped" to this specific collection
-                            // in case the response is None -> just continue
-                            if collection_ctx.is_some() {
-                                return Ok((Some(api_token.creator_user_id), api_token));
+                                // If an associated admin_user_perm is found, this can return a new context
+                                // for the admin scope
+                                if admin_user_perm.is_some() {
+                                    return Ok((Some(api_token.creator_user_id), api_token));
+                                }
                             }
-                        }
 
-                        // Case 4:
-                        // When the request is a collection_id that does not directly match
-                        // apitoken.collection_id or apitoken.project_id but api_token is project scoped
-                        // It might be possible that the collection is part of the "scoped" project
-                        // This checks if the collection is part of the "scoped" project
-                        // and returns early
-                        if api_token.project_id.is_some() {
-                            let is_collection_in_project = collections
-                                .filter(
-                                    crate::database::schema::collections::dsl::id
-                                        .eq(req_ctx.resource_id),
-                                )
-                                .filter(
-                                    crate::database::schema::collections::dsl::project_id
-                                        .eq(api_token.project_id.unwrap_or_default()),
-                                )
-                                .select(crate::database::schema::collections::dsl::id)
-                                .first::<diesel_ulid::DieselUlid>(conn)
-                                .optional()?;
-
-                            let col_in_proj_context = option_uuid_helper(
-                                Some(req_ctx.resource_id),
-                                is_collection_in_project,
-                                Resources::COLLECTION,
-                                req_ctx.user_right,
-                                api_token.user_right,
-                            );
-
-                            if col_in_proj_context.is_some() {
-                                return Ok((Some(api_token.creator_user_id), api_token));
+                            // Case 2:
+                            // The request is a "personal" scope
+                            // This can immediately return the user_id if the token is also personal scoped
+                            // Mostly used to modify tokens
+                            if req_ctx.personal {
+                                if api_token.project_id.is_none()
+                                    && api_token.collection_id.is_none()
+                                {
+                                    return Ok((Some(api_token.creator_user_id), api_token));
+                                } else {
+                                    return Err(dError::NotFound);
+                                }
                             }
-                        }
 
-                        // Case 6:
-                        // This is the case when the request is Collection scoped but the ApiToken is "personal"
-                        // -> no collection_id or project_id is specified
-                        // in this case it needs to be checked if the user_permission for the collections project exists
-                        if api_token.collection_id.is_none() && api_token.project_id.is_none() {
-                            // SELECT * from userpermissions INNER JOIN collections on project_id;
-                            let user_permission_option: Option<UserPermission> = user_permissions
+                            // If the requested context / scope is of type COLLECTION
+                            if req_ctx.resource_type == Resources::COLLECTION {
+                                // Case 3:
+                                // If api_token.collection_id == context_collection_id
+                                // And user_right != None && api_token.collection_id != None && context_collection_id != None
+                                // This will return Some(Context) otherwise this will return None
+                                if api_token.collection_id.is_some() {
+                                    let collection_ctx = option_uuid_helper(
+                                        api_token.collection_id,
+                                        Some(req_ctx.resource_id),
+                                        Resources::COLLECTION,
+                                        req_ctx.user_right,
+                                        api_token.user_right,
+                                    );
+
+                                    // If apitoken.collection_id == context_collection_id
+                                    // We can return early here -> The ApiToken is "scoped" to this specific collection
+                                    // in case the response is None -> just continue
+                                    if collection_ctx.is_some() {
+                                        return Ok((Some(api_token.creator_user_id), api_token));
+                                    }
+                                }
+
+                                // Case 4:
+                                // When the request is a collection_id that does not directly match
+                                // apitoken.collection_id or apitoken.project_id but api_token is project scoped
+                                // It might be possible that the collection is part of the "scoped" project
+                                // This checks if the collection is part of the "scoped" project
+                                // and returns early
+                                if api_token.project_id.is_some() {
+                                    let is_collection_in_project = collections
+                                        .filter(
+                                            crate::database::schema::collections::dsl::id
+                                                .eq(req_ctx.resource_id),
+                                        )
+                                        .filter(
+                                            crate::database::schema::collections::dsl::project_id
+                                                .eq(api_token.project_id.unwrap_or_default()),
+                                        )
+                                        .select(crate::database::schema::collections::dsl::id)
+                                        .first::<diesel_ulid::DieselUlid>(conn)
+                                        .optional()?;
+
+                                    let col_in_proj_context = option_uuid_helper(
+                                        Some(req_ctx.resource_id),
+                                        is_collection_in_project,
+                                        Resources::COLLECTION,
+                                        req_ctx.user_right,
+                                        api_token.user_right,
+                                    );
+
+                                    if col_in_proj_context.is_some() {
+                                        return Ok((Some(api_token.creator_user_id), api_token));
+                                    }
+                                }
+
+                                // Case 6:
+                                // This is the case when the request is Collection scoped but the ApiToken is "personal"
+                                // -> no collection_id or project_id is specified
+                                // in this case it needs to be checked if the user_permission for the collections project exists
+                                if api_token.collection_id.is_none()
+                                    && api_token.project_id.is_none()
+                                {
+                                    // SELECT * from userpermissions INNER JOIN collections on project_id;
+                                    let user_permission_option: Option<UserPermission> =
+                            user_permissions
                                 .inner_join(collections.on(
                                     crate::database::schema::collections::dsl::project_id.eq(
                                         crate::database::schema::user_permissions::dsl::project_id,
@@ -256,73 +271,108 @@ impl Database {
                                 .first::<UserPermission>(conn)
                                 .optional()?;
 
-                            if let Some(user_perm) = user_permission_option {
-                                let col_in_proj_ctx2 = option_uuid_helper(
-                                    Some(req_ctx.resource_id),
-                                    Some(req_ctx.resource_id),
-                                    Resources::COLLECTION,
-                                    req_ctx.user_right,
-                                    Some(user_perm.user_right), // This unwrap is ok safe because project_valid.is_some()
-                                );
+                                    if let Some(user_perm) = user_permission_option {
+                                        let col_in_proj_ctx2 = option_uuid_helper(
+                                            Some(req_ctx.resource_id),
+                                            Some(req_ctx.resource_id),
+                                            Resources::COLLECTION,
+                                            req_ctx.user_right,
+                                            Some(user_perm.user_right), // This unwrap is ok safe because project_valid.is_some()
+                                        );
 
-                                if col_in_proj_ctx2.is_some() {
-                                    return Ok((Some(api_token.creator_user_id), api_token));
+                                        if col_in_proj_ctx2.is_some() {
+                                            return Ok((
+                                                Some(api_token.creator_user_id),
+                                                api_token,
+                                            ));
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    if req_ctx.resource_type == Resources::PROJECT {
-                        // Case 5:
-                        // If api_token.project_id == context_project_id
-                        // And user_right != None && api_token.project_id != None && context_project_id != None
-                        // This will return Some(Context) otherwise this will return None
-                        if api_token.project_id.is_some() {
-                            let project_ctx = option_uuid_helper(
-                                api_token.project_id,
-                                Some(req_ctx.resource_id),
-                                Resources::PROJECT,
-                                req_ctx.user_right,
-                                api_token.user_right,
-                            );
+                            if req_ctx.resource_type == Resources::PROJECT {
+                                // Case 5:
+                                // If api_token.project_id == context_project_id
+                                // And user_right != None && api_token.project_id != None && context_project_id != None
+                                // This will return Some(Context) otherwise this will return None
+                                if api_token.project_id.is_some() {
+                                    let project_ctx = option_uuid_helper(
+                                        api_token.project_id,
+                                        Some(req_ctx.resource_id),
+                                        Resources::PROJECT,
+                                        req_ctx.user_right,
+                                        api_token.user_right,
+                                    );
 
-                            // If apitoken.collection_id == context_collection_id
-                            // We can return early here -> The ApiToken is "scoped" to this specific collection
-                            if project_ctx.is_some() {
-                                return Ok((Some(api_token.creator_user_id), api_token));
-                            }
-                        }
+                                    // If apitoken.collection_id == context_collection_id
+                                    // We can return early here -> The ApiToken is "scoped" to this specific collection
+                                    if project_ctx.is_some() {
+                                        return Ok((Some(api_token.creator_user_id), api_token));
+                                    }
+                                }
 
-                        // Case 7:
-                        // If context is user_scoped check if the user has the correct project permissions
-                        // This checks for the permissions in the user_permissions table which already contains a project_id
-                        if api_token.project_id.is_none() && api_token.collection_id.is_none() {
-                            let user_permissions_option = user_permissions
-                                .filter(user_id.eq(&api_token.creator_user_id))
-                                .filter(
-                                    crate::database::schema::user_permissions::dsl::project_id
-                                        .eq(req_ctx.resource_id),
-                                )
-                                .first::<UserPermission>(conn)
-                                .optional()?;
-                            if user_permissions_option.is_some() {
-                                let col_in_proj_ctx = option_uuid_helper(
-                                    Some(user_permissions_option.as_ref().unwrap().project_id), // This unwrap is ok safe because project_valid.is_some()
-                                    Some(req_ctx.resource_id),
-                                    Resources::PROJECT,
-                                    req_ctx.user_right,
-                                    Some(user_permissions_option.as_ref().unwrap().user_right), // This unwrap is ok safe because project_valid.is_some()
-                                );
+                                // Case 7:
+                                // If context is user_scoped check if the user has the correct project permissions
+                                // This checks for the permissions in the user_permissions table which already contains a project_id
+                                if api_token.project_id.is_none()
+                                    && api_token.collection_id.is_none()
+                                {
+                                    let user_permissions_option = user_permissions
+                            .filter(user_id.eq(&api_token.creator_user_id))
+                            .filter(
+                                crate::database::schema::user_permissions::dsl::project_id
+                                    .eq(req_ctx.resource_id),
+                            )
+                            .first::<UserPermission>(conn)
+                            .optional()?;
+                                    if user_permissions_option.is_some() {
+                                        let col_in_proj_ctx = option_uuid_helper(
+                                            Some(
+                                                user_permissions_option
+                                                    .as_ref()
+                                                    .unwrap()
+                                                    .project_id,
+                                            ), // This unwrap is ok safe because project_valid.is_some()
+                                            Some(req_ctx.resource_id),
+                                            Resources::PROJECT,
+                                            req_ctx.user_right,
+                                            Some(
+                                                user_permissions_option
+                                                    .as_ref()
+                                                    .unwrap()
+                                                    .user_right,
+                                            ), // This unwrap is ok safe because project_valid.is_some()
+                                        );
 
-                                if col_in_proj_ctx.is_some() {
-                                    return Ok((Some(api_token.creator_user_id), api_token));
+                                        if col_in_proj_ctx.is_some() {
+                                            return Ok((
+                                                Some(api_token.creator_user_id),
+                                                api_token,
+                                            ));
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    Ok((None, api_token))
-                })?;
+                            Ok((None, api_token))
+                        },
+                    );
+
+            match transaction_result {
+                Ok(_) => {
+                    break;
+                }
+                Err(_) => {
+                    thread::sleep(time::Duration::from_millis(backoff as u64));
+                    backoff = i32::pow(backoff, 2);
+                    if backoff > 100000 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let (creator_uid, api_token) = transaction_result?;
 
         match creator_uid {
             Some(uid) => Ok((uid, api_token)),

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -4734,7 +4734,10 @@ pub fn create_path_db(
     //     .optional()?)
     // .is_none()
     // {
-    diesel::insert_into(paths).values(path_obj).execute(conn)?;
+    diesel::insert_into(paths)
+        .values(path_obj)
+        .on_conflict_do_nothing()
+        .execute(conn)?;
     // };
 
     Ok(())

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -4735,15 +4735,16 @@ pub fn create_path_db(
         active: true,
     };
 
-    if (paths
-        .filter(database::schema::paths::bucket.eq(s3bucket))
-        .filter(database::schema::paths::path.eq(s3path))
-        .first::<Path>(conn)
-        .optional()?)
-    .is_none()
-    {
-        diesel::insert_into(paths).values(path_obj).execute(conn)?;
-    };
+    // Can be removed because of unique constraint on s3bucket/s3path
+    // if (paths
+    //     .filter(database::schema::paths::bucket.eq(s3bucket))
+    //     .filter(database::schema::paths::path.eq(s3path))
+    //     .first::<Path>(conn)
+    //     .optional()?)
+    // .is_none()
+    // {
+    diesel::insert_into(paths).values(path_obj).execute(conn)?;
+    // };
 
     Ok(())
 }

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -81,7 +81,7 @@ pub struct ObjectDto {
     pub object: Object,
     pub labels: Vec<KeyValue>,
     pub hooks: Vec<KeyValue>,
-    pub hashes: Vec<ApiHash>,
+    pub object_hashes: Vec<ApiHash>,
     pub source: Option<Source>,
     pub latest: bool,
     pub update: bool,
@@ -92,7 +92,7 @@ impl PartialEq for ObjectDto {
         self.object == other.object
             && self.labels == other.labels
             && self.hooks == other.hooks
-            && self.hashes == other.hashes
+            && self.object_hashes == other.object_hashes
             && self.source == other.source
             && self.latest == other.latest
             && self.update == other.update
@@ -127,7 +127,7 @@ impl TryFrom<ObjectDto> for ProtoObject {
         let timestamp = naivedatetime_to_prost_time(object_dto.object.created_at)?;
 
         let proto_hashes = object_dto
-            .hashes
+            .object_hashes
             .iter()
             .map(|h| ProtoHash {
                 //alg: object_dto.hash.hash_type as i32,
@@ -4439,7 +4439,7 @@ pub fn get_object(
                 object,
                 labels,
                 hooks,
-                hashes: object_hashes,
+                object_hashes: object_hashes,
                 source,
                 latest,
                 update: colobj.auto_update,
@@ -4503,7 +4503,7 @@ pub fn get_object_ignore_coll(
         object,
         labels,
         hooks,
-        hashes: object_hash,
+        object_hashes: object_hash,
         source,
         latest,
         update: false, // Always false might not include any collection_info

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -3,6 +3,8 @@ use std::convert::TryInto;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::str::FromStr;
+use std::thread;
+use std::time;
 
 use diesel::dsl::{count, max, min};
 use diesel::r2d2::ConnectionManager;
@@ -197,14 +199,16 @@ impl Database {
         let collection_uuid =
             diesel_ulid::DieselUlid::from_str(&request.collection_id).map_err(ArunaError::from)?;
 
+        let mut connection = self.pg_connection.get()?;
+
+        let mut backoff = 10;
+        let mut transaction_result;
         // Insert staging object with all its needed assets into database
-        let created_object = self
-            .pg_connection
-            .get()?
-            .transaction::<Object, ArunaError, _>(|conn| {
+        loop {
+            transaction_result = connection.transaction::<Object, ArunaError, _>(|conn| {
                 create_staging_object(
                     conn,
-                    staging_object,
+                    staging_object.clone(),
                     &object_uuid,
                     request.hash.clone(),
                     &collection_uuid,
@@ -212,8 +216,21 @@ impl Database {
                     request.is_specification,
                     Some(endpoint_uuid),
                 )
-            })?;
+            });
 
+            match transaction_result {
+                Ok(_) => break,
+                Err(_) => {
+                    thread::sleep(time::Duration::from_millis(backoff as u64));
+                    backoff = i32::pow(backoff, 2);
+                    if backoff > 100000 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let created_object = transaction_result?;
         // Return response which is missing the upload id which will be created by upload init
         Ok(InitializeNewObjectResponse {
             object_id: created_object.id.to_string(),
@@ -231,119 +248,136 @@ impl Database {
         let req_object_uuid = diesel_ulid::DieselUlid::from_str(&request.object_id)?;
         let req_coll_uuid = diesel_ulid::DieselUlid::from_str(&request.collection_id)?;
 
+        let mut connection = self.pg_connection.get()?;
+        let mut backoff = 10;
+        let mut transaction_result;
+
         // Insert all defined objects into the database
-        let object_dto = self
-            .pg_connection
-            .get()?
-            .transaction::<Option<ObjectDto>, ArunaError, _>(|conn| {
-                // Check if object is latest!
-                let latest = get_latest_obj(conn, req_object_uuid)?;
-                let is_still_latest = latest.id == req_object_uuid;
 
-                if !is_still_latest {
-                    return Err(ArunaError::InvalidRequest(format!(
-                        "Object {req_object_uuid} is not latest revision. "
-                    )));
-                }
+        loop {
+            transaction_result =
+                connection.transaction::<Option<ObjectDto>, ArunaError, _>(|conn| {
+                    // Check if object is latest!
+                    let latest = get_latest_obj(conn, req_object_uuid)?;
+                    let is_still_latest = latest.id == req_object_uuid;
 
-                // What can we do here ?
-                // - Set auto update ?
-                // - Set or check expected hashes
-                // - Finalize EMPTY object ?
+                    if !is_still_latest {
+                        return Err(ArunaError::InvalidRequest(format!(
+                            "Object {req_object_uuid} is not latest revision. "
+                        )));
+                    }
 
-                // // Update the object itself to be available
-                // let returned_obj = diesel::update(
-                //     objects.filter(database::schema::objects::id.eq(req_object_uuid)),
-                // )
-                // .set(database::schema::objects::object_status.eq(ObjectStatus::AVAILABLE))
-                // .get_result::<Object>(conn)?;
+                    // What can we do here ?
+                    // - Set auto update ?
+                    // - Set or check expected hashes
+                    // - Finalize EMPTY object ?
 
-                // Update hash if (re-)upload and request contains hash
-                if !request.no_upload && request.hash.is_some() {
-                    (match &request.hash {
-                        None => {
-                            return Err(ArunaError::InvalidRequest(
-                                "Missing hash after re-upload.".to_string(),
-                            ));
-                        }
-                        Some(req_hash) => diesel::update(ApiHash::belonging_to(&latest))
-                            .set((
-                                database::schema::hashes::hash.eq(&req_hash.hash),
-                                database::schema::hashes::hash_type
-                                    .eq(HashType::from_grpc(req_hash.alg)),
-                            ))
-                            .execute(conn),
-                    })?;
-                }
+                    // // Update the object itself to be available
+                    // let returned_obj = diesel::update(
+                    //     objects.filter(database::schema::objects::id.eq(req_object_uuid)),
+                    // )
+                    // .set(database::schema::objects::object_status.eq(ObjectStatus::AVAILABLE))
+                    // .get_result::<Object>(conn)?;
 
-                // Check if the origin id is different from uuid
-                // This indicates an "updated" object and not a new one
-                // Finishing updates need extra steps to update all references
-                // In other collections / objectgroups
+                    // Update hash if (re-)upload and request contains hash
+                    if !request.no_upload && request.hash.is_some() {
+                        (match &request.hash {
+                            None => {
+                                return Err(ArunaError::InvalidRequest(
+                                    "Missing hash after re-upload.".to_string(),
+                                ));
+                            }
+                            Some(req_hash) => diesel::update(ApiHash::belonging_to(&latest))
+                                .set((
+                                    database::schema::hashes::hash.eq(&req_hash.hash),
+                                    database::schema::hashes::hash_type
+                                        .eq(HashType::from_grpc(req_hash.alg)),
+                                ))
+                                .execute(conn),
+                        })?;
+                    }
 
-                if latest.object_status != ObjectStatus::AVAILABLE {
-                    update(objects)
-                        .filter(database::schema::objects::id.eq(&req_object_uuid))
-                        .set((
-                            database::schema::objects::object_status.eq(ObjectStatus::FINALIZING),
-                        ))
-                        .execute(conn)?;
-                }
+                    // Check if the origin id is different from uuid
+                    // This indicates an "updated" object and not a new one
+                    // Finishing updates need extra steps to update all references
+                    // In other collections / objectgroups
 
-                // Special treatment if only metadata was updated
-                if request.no_upload {
-                    // Only on update without upload
-                    if latest.origin_id != req_object_uuid {
-                        // Clone object locations of old object with new object id as data stays the same.
-                        let mut cloned_locations = Vec::new();
-                        for old_location in object_locations
-                            .filter(
-                                database::schema::object_locations::object_id.eq(&latest.origin_id),
-                            )
-                            .load::<ObjectLocation>(conn)?
-                        {
-                            cloned_locations.push(ObjectLocation {
-                                id: diesel_ulid::DieselUlid::generate(),
-                                bucket: old_location.bucket,
-                                path: old_location.path,
-                                endpoint_id: old_location.endpoint_id,
-                                object_id: req_object_uuid,
-                                is_primary: old_location.is_primary,
-                                is_encrypted: old_location.is_encrypted,
-                                is_compressed: old_location.is_compressed,
-                            });
-                        }
-                        insert_into(object_locations)
-                            .values(&cloned_locations)
-                            .execute(conn)?;
-
-                        // Clone encryption keys of old object for specific data hashes
-                        let mut cloned_keys = Vec::new();
-                        for old_key in encryption_keys
-                            .filter(
-                                database::schema::encryption_keys::object_id.eq(&latest.origin_id),
-                            )
-                            .load::<EncryptionKey>(conn)?
-                        {
-                            cloned_keys.push(EncryptionKey {
-                                id: diesel_ulid::DieselUlid::generate(),
-                                hash: old_key.hash,
-                                object_id: req_object_uuid,
-                                endpoint_id: old_key.endpoint_id,
-                                is_temporary: old_key.is_temporary,
-                                encryption_key: old_key.encryption_key,
-                            });
-                        }
-                        insert_into(encryption_keys)
-                            .values(&cloned_keys)
+                    if latest.object_status != ObjectStatus::AVAILABLE {
+                        update(objects)
+                            .filter(database::schema::objects::id.eq(&req_object_uuid))
+                            .set((database::schema::objects::object_status
+                                .eq(ObjectStatus::FINALIZING),))
                             .execute(conn)?;
                     }
 
-                    set_object_available(conn, &latest, &req_coll_uuid, None)?;
-                }
+                    // Special treatment if only metadata was updated
+                    if request.no_upload {
+                        // Only on update without upload
+                        if latest.origin_id != req_object_uuid {
+                            // Clone object locations of old object with new object id as data stays the same.
+                            let mut cloned_locations = Vec::new();
+                            for old_location in object_locations
+                                .filter(
+                                    database::schema::object_locations::object_id
+                                        .eq(&latest.origin_id),
+                                )
+                                .load::<ObjectLocation>(conn)?
+                            {
+                                cloned_locations.push(ObjectLocation {
+                                    id: diesel_ulid::DieselUlid::generate(),
+                                    bucket: old_location.bucket,
+                                    path: old_location.path,
+                                    endpoint_id: old_location.endpoint_id,
+                                    object_id: req_object_uuid,
+                                    is_primary: old_location.is_primary,
+                                    is_encrypted: old_location.is_encrypted,
+                                    is_compressed: old_location.is_compressed,
+                                });
+                            }
+                            insert_into(object_locations)
+                                .values(&cloned_locations)
+                                .execute(conn)?;
 
-                Ok(get_object(&req_object_uuid, &req_coll_uuid, true, conn)?)
-            })?;
+                            // Clone encryption keys of old object for specific data hashes
+                            let mut cloned_keys = Vec::new();
+                            for old_key in encryption_keys
+                                .filter(
+                                    database::schema::encryption_keys::object_id
+                                        .eq(&latest.origin_id),
+                                )
+                                .load::<EncryptionKey>(conn)?
+                            {
+                                cloned_keys.push(EncryptionKey {
+                                    id: diesel_ulid::DieselUlid::generate(),
+                                    hash: old_key.hash,
+                                    object_id: req_object_uuid,
+                                    endpoint_id: old_key.endpoint_id,
+                                    is_temporary: old_key.is_temporary,
+                                    encryption_key: old_key.encryption_key,
+                                });
+                            }
+                            insert_into(encryption_keys)
+                                .values(&cloned_keys)
+                                .execute(conn)?;
+                        }
+
+                        set_object_available(conn, &latest, &req_coll_uuid, None)?;
+                    }
+
+                    Ok(get_object(&req_object_uuid, &req_coll_uuid, true, conn)?)
+                });
+            match transaction_result {
+                Ok(_) => break,
+                Err(_) => {
+                    thread::sleep(time::Duration::from_millis(backoff as u64));
+                    backoff = i32::pow(backoff, 2);
+                    if backoff > 100000 {
+                        break;
+                    }
+                }
+            }
+        }
+        let object_dto = transaction_result?;
 
         let mapped = object_dto
             .map(|e| e.try_into())

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -4500,7 +4500,7 @@ pub fn get_object(
                 object,
                 labels,
                 hooks,
-                object_hashes: object_hashes,
+                object_hashes,
                 source,
                 latest,
                 update: colobj.auto_update,

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -415,19 +415,29 @@ impl ObjectService for ObjectServiceImpl {
                 collection_uuid, // This is the collection uuid in which this object should be created
                 UserRights::APPEND, // User needs at least append permission to create an object
             )
-            .await?;
+            .await
+            .unwrap();
 
         // Consume gRPC request
         let inner_request = request.into_inner();
 
         // Fetch staging object to get temp path from init
-        let staging_object = self
-            .database
-            .get_object_by_id(&object_uuid, &collection_uuid)?
-            .object
-            .ok_or(ArunaError::InvalidRequest(format!(
+
+        let database_clone = self.database.clone();
+        let staging_object = task::spawn_blocking(move || {
+            database_clone
+                .get_object_by_id(&object_uuid, &collection_uuid)?
+                .object
+                .ok_or(ArunaError::InvalidRequest(format!(
+                    "Could not find object {object_uuid} in collection {collection_uuid}"
+                )))
+        })
+        .await
+        .map_err(|_| {
+            ArunaError::InvalidRequest(format!(
                 "Could not find object {object_uuid} in collection {collection_uuid}"
-            )))?;
+            ))
+        })??;
 
         // Check if object status is still INITIALIZING
         if grpc_to_db_object_status(&staging_object.status) != ObjectStatus::INITIALIZING {

--- a/src/server/services/user.rs
+++ b/src/server/services/user.rs
@@ -191,7 +191,7 @@ impl UserService for UserServiceImpl {
                             ",
                             &response.id.to_string()
                         ),
-                        &format!("Welcome to Aruna!"),
+                        "Welcome to Aruna!",
                     ) {
                         Ok(()) => {}
                         Err(e) => {

--- a/tests/sources/up.sql
+++ b/tests/sources/up.sql
@@ -144,7 +144,7 @@ CREATE TABLE sources (
 -- Table with objects which represent individual data blobs
 CREATE TABLE objects (
     -- The unique per object id
-    id UUID NOT NULL,
+    id UUID NOT NULL PRIMARY KEY,
     shared_revision_id UUID NOT NULL,
     revision_number INT NOT NULL,
     filename TEXT NOT NULL,
@@ -155,13 +155,13 @@ CREATE TABLE objects (
     dataclass DATACLASS NOT NULL DEFAULT 'PRIVATE',
     source_id UUID REFERENCES sources(id),
     origin_id UUID NOT NULL,
-    PRIMARY KEY (id),
     FOREIGN KEY (created_by) REFERENCES users(id)
 );
 ALTER TABLE objects
 ADD FOREIGN KEY (origin_id) REFERENCES objects(id);
 -- objects table cannot reference itself until created
-CREATE INDEX objects_id_idx ON objects (shared_revision_id, revision_number);
+CREATE INDEX objects_shared_rev_idx ON objects (shared_revision_id, revision_number);
+CREATE INDEX objects_shared_single_idx ON objects (shared_revision_id);
 -- Table with endpoints
 CREATE TABLE endpoints (
     id UUID PRIMARY KEY,
@@ -196,6 +196,8 @@ CREATE TABLE hashes (
     hash_type HASH_TYPE NOT NULL,
     FOREIGN KEY (object_id) REFERENCES objects(id)
 );
+CREATE INDEX hashes_objects_idx ON hashes (object_id);
+
 -- Table with the key-value pairs associated with specific objects
 CREATE TABLE object_key_value (
     id UUID PRIMARY KEY,
@@ -205,6 +207,7 @@ CREATE TABLE object_key_value (
     key_value_type KEY_VALUE_TYPE NOT NULL,
     FOREIGN KEY (object_id) REFERENCES objects(id)
 );
+CREATE INDEX object_key_value_objects_idx ON object_key_value (object_id);
 /* ----- ObjectGroups ---------------------------------------------- */
 -- Table with object groups which act as a single level organization for objects in collections
 CREATE TABLE object_groups (
@@ -246,6 +249,8 @@ CREATE TABLE collection_objects (
     FOREIGN KEY (collection_id) REFERENCES collections(id),
     CONSTRAINT unique_collection_object UNIQUE (object_id, collection_id)
 );
+CREATE INDEX collection_objects_collection_idx ON collection_objects (collection_id);
+CREATE INDEX collection_objects_objects_idx ON collection_objects (object_id);
 -- Join table between collections and object_groups
 CREATE TABLE collection_object_groups (
     id UUID PRIMARY KEY,


### PR DESCRIPTION
This is a first set of fixes for #75 

Very large database transactions lead to a high likelihood of table and index contention. To temporarily make this problem less prominent this PR includes the following changes:

### Changes

- Added more indices for heavy contended tables (collection_object, paths etc.)
- Added retry with backoff for inserts and auth
- Added some querys with `FOR UPDATE` selects to lock rows before they are updated.

### Result

This heavily reduces the number of contention events but does not eliminate them completely. Future fixes should address this by either reducing overall transaction size and/or denormalization of tables to reduce needed locks / tracked relations.