### PR TITLE
Fix collection deletion including required labels

### DIFF
--- a/src/database/crud/collection.rs
+++ b/src/database/crud/collection.rs
@@ -22,6 +22,7 @@ use crate::database::models::object::{Object, ObjectKeyValue, Relation};
 use crate::database::models::object_group::{ObjectGroup, ObjectGroupKeyValue, ObjectGroupObject};
 use crate::database::models::views::CollectionStat;
 use crate::database::schema::collections::dsl::collections;
+use crate::database::schema::required_labels;
 use crate::error::{ArunaError, TypeConversionError};
 use aruna_rust_api::api::storage::models::v1::DataClass;
 use aruna_rust_api::api::storage::models::v1::{
@@ -757,10 +758,17 @@ impl Database {
                     )?;
                 //}
             }
+
+            // Delete associated label_ontologies before labels
+            delete(database::schema::required_labels::dsl::required_labels.filter(
+                required_labels::collection_id.eq(&collection_ulid)
+            )).execute(conn)?;
+
             // Delete all collection_key_values
             delete(
                 colkv::collection_key_value.filter(colkv::collection_id.eq(&collection_ulid))
             ).execute(conn)?;
+
             // Delete the collection
             delete(col::collections.filter(col::id.eq(&collection_ulid))).execute(conn)?;
 

--- a/tests/common/functions.rs
+++ b/tests/common/functions.rs
@@ -296,15 +296,24 @@ pub fn create_collection(tccol: TCreateCollection) -> CollectionOverview {
         get_col_resp.version.clone().unwrap(),
         collection_overview::Version::Latest(true)
     );
-    assert!(
-        // Should be empty vec
-        get_col_resp
-            .label_ontology
-            .clone()
-            .unwrap()
-            .required_label_keys
-            .is_empty()
-    );
+
+    // Required labels should be empty if no label ontology was provided
+    if create_collection_request_test
+        .request
+        .label_ontology
+        .is_none()
+    {
+        assert!(
+            // Should be empty vec
+            get_col_resp
+                .label_ontology
+                .clone()
+                .unwrap()
+                .required_label_keys
+                .is_empty()
+        );
+    }
+
     // Labels / Hooks should be the same
     assert!({
         get_col_resp

--- a/tests/d2_collection_grpc_tests.rs
+++ b/tests/d2_collection_grpc_tests.rs
@@ -1181,5 +1181,42 @@ async fn delete_collection_grpc_test() {
         common::oidc::REGULARTOKEN
     )
     .await
-    .is_none())
+    .is_none());
+
+    // Try to delete collection with label_ontology
+    let random_collection = common::functions::create_collection(TCreateCollection {
+        project_id: random_project.id.to_string(),
+        num_labels: 0,
+        num_hooks: 0,
+        col_override: Some(CreateNewCollectionRequest {
+            name: "label-ontology-collection".to_string(),
+            description: "Some description".to_string(),
+            project_id: random_project.id.to_string(),
+            labels: vec![],
+            hooks: vec![KeyValue {
+                key: "required".to_string(),
+                value: "true".to_string(),
+            }],
+            label_ontology: Some(LabelOntology {
+                required_label_keys: vec!["required".to_string()],
+            }),
+            dataclass: 1,
+        }),
+        creator_id: Some(user_id.to_string()),
+    });
+
+    let delete_collection_request = common::grpc_helpers::add_token(
+        tonic::Request::new(DeleteCollectionRequest {
+            collection_id: random_collection.id.to_string(),
+            force: true,
+        }),
+        common::oidc::REGULARTOKEN,
+    );
+    let delete_collection_response = collection_service
+        .delete_collection(delete_collection_request)
+        .await;
+
+    println!("{:#?}", delete_collection_response);
+
+    delete_collection_response.unwrap();
 }


### PR DESCRIPTION
Small PR which fixes #88 .

## Changes

* `required_label` entries associated with the collection are also deleted before the collection itself