### PR TITLE
feat: Feat/service accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "aruna-rust-api"
-version = "1.1.0-rc.6"
+version = "1.1.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a66bf316f5e892fc0addabe2f5ecee75c0b2862d63b0fa06880fa7f56d8f878"
+checksum = "d54aa78e6b6f9c37b2a6188f15ffdff5c2562462bd72065766d86bd5a1197ecc"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.71"
-aruna-rust-api = "1.1.0-rc.6"
+aruna-rust-api = "1.1.0-rc.7"
 bigdecimal = "0.3.1"
 chrono = "0.4.26"
 diesel = {version = "2.1.0", features = ["postgres", "uuid", "r2d2", "chrono", "numeric", "serde_json"]}

--- a/src/database/crud/mod.rs
+++ b/src/database/crud/mod.rs
@@ -8,5 +8,6 @@ pub mod notifications;
 pub mod object;
 pub mod objectgroups;
 pub mod project;
+pub mod service_accounts;
 pub mod user;
 pub mod utils;

--- a/src/database/crud/object.rs
+++ b/src/database/crud/object.rs
@@ -1053,6 +1053,7 @@ impl Database {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )?;
 
@@ -2370,6 +2371,7 @@ impl Database {
                         admin: false,
                         personal: false,
                         oidc_context: false,
+                        allow_service_accounts: true,
                     },
                 )?;
 

--- a/src/database/crud/service_accounts.rs
+++ b/src/database/crud/service_accounts.rs
@@ -17,7 +17,6 @@ use crate::{
         connection::Database,
         crud::utils::map_permissions,
         models::auth::{ApiToken, User, UserPermission},
-        schema::api_tokens,
     },
     error::ArunaError,
 };
@@ -100,12 +99,15 @@ impl Database {
             .map(char::from)
             .collect();
 
+        let perm_to_insert = map_permissions(request.permission());
+
         let (proj, col) = match request.collection_id.is_empty() {
-            true => (Some(DieselUlid::from_str(&request.project_id)?), None),
+            true => match perm_to_insert {
+                Some(_) => (Some(DieselUlid::from_str(&request.project_id)?), None),
+                None => (None, None),
+            },
             false => (None, Some(DieselUlid::from_str(&request.collection_id)?)),
         };
-
-        let perm_to_insert = map_permissions(request.permission());
 
         let token_to_insert = ApiToken {
             id: DieselUlid::generate(),

--- a/src/database/crud/service_accounts.rs
+++ b/src/database/crud/service_accounts.rs
@@ -1,0 +1,68 @@
+use std::str::FromStr;
+
+use aruna_rust_api::api::storage::services::v1::{
+    CreateServiceAccountRequest, CreateServiceAccountResponse, ServiceAccount,
+};
+use diesel::{insert_into, Connection, RunQueryDsl};
+
+use crate::{
+    database::{
+        connection::Database,
+        crud::utils::map_permissions,
+        models::auth::{User, UserPermission},
+    },
+    error::ArunaError,
+};
+
+impl Database {
+    pub fn create_service_account(
+        &self,
+        request: CreateServiceAccountRequest,
+    ) -> Result<CreateServiceAccountResponse, ArunaError> {
+        use crate::database::schema::user_permissions::dsl::*;
+        use crate::database::schema::users::dsl::*;
+
+        // Create a new DB user object
+        let db_user = User {
+            id: diesel_ulid::DieselUlid::generate(),
+            display_name: request.name.to_string(),
+            external_id: "".to_string(),
+            active: true,
+            is_service_account: true,
+            email: "".to_string(),
+        };
+
+        let user_perm = UserPermission {
+            id: diesel_ulid::DieselUlid::generate(),
+            user_id: db_user.id,
+            user_right: map_permissions(request.permission().clone()).ok_or(
+                ArunaError::InvalidRequest("Invalid svc account permission".to_string()),
+            )?,
+            project_id: diesel_ulid::DieselUlid::from_str(&request.project_id)?,
+        };
+
+        // Insert the user and return the user_id
+        let uid = self
+            .pg_connection
+            .get()?
+            .transaction::<diesel_ulid::DieselUlid, ArunaError, _>(|conn| {
+                let uid = insert_into(users)
+                    .values(&db_user)
+                    .returning(crate::database::schema::users::id)
+                    .get_result(conn)?;
+                insert_into(user_permissions)
+                    .values(&user_perm)
+                    .execute(conn)?;
+                Ok(uid)
+            })?;
+
+        Ok(CreateServiceAccountResponse {
+            service_account: Some(ServiceAccount {
+                svc_account_id: uid.to_string(),
+                project_id: request.project_id.to_string(),
+                name: request.name.to_string(),
+                permission: request.permission.clone(),
+            }),
+        })
+    }
+}

--- a/src/database/crud/service_accounts.rs
+++ b/src/database/crud/service_accounts.rs
@@ -1,15 +1,23 @@
 use std::str::FromStr;
 
-use aruna_rust_api::api::storage::services::v1::{
-    CreateServiceAccountRequest, CreateServiceAccountResponse, ServiceAccount,
+use aruna_rust_api::api::storage::{
+    models::v1::Token,
+    services::v1::{
+        CreateServiceAccountRequest, CreateServiceAccountResponse,
+        CreateServiceAccountTokenRequest, CreateServiceAccountTokenResponse, ServiceAccount,
+    },
 };
-use diesel::{insert_into, Connection, RunQueryDsl};
+use chrono::Utc;
+use diesel::{insert_into, BelongingToDsl, Connection, ExpressionMethods, QueryDsl, RunQueryDsl};
+use diesel_ulid::DieselUlid;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 use crate::{
     database::{
         connection::Database,
         crud::utils::map_permissions,
-        models::auth::{User, UserPermission},
+        models::auth::{ApiToken, User, UserPermission},
+        schema::api_tokens,
     },
     error::ArunaError,
 };
@@ -63,6 +71,94 @@ impl Database {
                 name: request.name.to_string(),
                 permission: request.permission.clone(),
             }),
+        })
+    }
+
+    pub fn create_service_account_token(
+        &self,
+        request: CreateServiceAccountTokenRequest,
+        creator: DieselUlid,
+        pubkey_ref: i64,
+    ) -> Result<CreateServiceAccountTokenResponse, ArunaError> {
+        use crate::database::schema::api_tokens::dsl::*;
+        use crate::database::schema::users::dsl::*;
+
+        // Get the svc account ulid
+        let svc_account_id = diesel_ulid::DieselUlid::from_str(&request.svc_account_id)?;
+
+        let exp_time = match &request.expires_at {
+            Some(t) => {
+                Some(chrono::NaiveDateTime::from_timestamp_opt(t.seconds, 0).unwrap_or_default())
+            }
+            None => None,
+        };
+
+        // Create random access_key
+        let secret_key: String = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(30)
+            .map(char::from)
+            .collect();
+
+        let (proj, col) = match request.collection_id.is_empty() {
+            true => (Some(DieselUlid::from_str(&request.project_id)?), None),
+            false => (None, Some(DieselUlid::from_str(&request.collection_id)?)),
+        };
+
+        let perm_to_insert = map_permissions(request.permission());
+
+        let token_to_insert = ApiToken {
+            id: DieselUlid::generate(),
+            creator_user_id: creator,
+            pub_key: pubkey_ref,
+            name: match request.name.is_empty() {
+                true => None,
+                false => Some(request.name.to_string()),
+            },
+            created_at: Utc::now().naive_local(),
+            expires_at: exp_time,
+            project_id: proj,
+            collection_id: col,
+            user_right: perm_to_insert.clone(),
+            secretkey: secret_key,
+            used_at: Utc::now().naive_local(),
+            is_session: false,
+        };
+
+        // Insert the user and return the user_id
+        self
+            .pg_connection
+            .get()?
+            .transaction::<(), ArunaError, _>(|conn| {
+                let account: User = users
+                    .filter(crate::database::schema::users::id.eq(svc_account_id))
+                    .first::<User>(conn)?;
+                if !account.is_service_account {
+                    return Err(ArunaError::InvalidRequest(
+                        "Account is no svc account".to_string(),
+                    ));
+                }
+
+                let perm: UserPermission =
+                    UserPermission::belonging_to(&account).first::<UserPermission>(conn)?;
+                if let Some(p) = perm_to_insert {
+                    if proj.is_some() {
+                        if perm.user_right < p {
+                            return Err(ArunaError::InvalidRequest("Invalid permission, service account has lower global project permissions.".to_string()))
+                        }
+                    }
+                };
+
+                insert_into(api_tokens).values(&token_to_insert).execute(conn)?;
+
+                Ok(())
+            })?;
+
+        Ok(CreateServiceAccountTokenResponse {
+            token: Some(Token::try_from(token_to_insert.clone())?),
+            token_secret: String::new(),
+            s3_access_key: token_to_insert.id.to_string(),
+            s3_secret_key: token_to_insert.secretkey.to_string(),
         })
     }
 }

--- a/src/database/crud/user.rs
+++ b/src/database/crud/user.rs
@@ -271,18 +271,7 @@ impl Database {
 
         // Create the response
         Ok((
-            Token {
-                id: api_token.id.to_string(),
-                name: api_token.name.unwrap_or_default(),
-                token_type: token_type as i32,
-                created_at: Some(naivedatetime_to_prost_time(api_token.created_at)?),
-                expires_at: expires_at_time,
-                collection_id: option_to_string(api_token.collection_id).unwrap_or_default(),
-                project_id: option_to_string(api_token.project_id).unwrap_or_default(),
-                permission: map_permissions_rev(api_token.user_right),
-                is_session: api_token.is_session,
-                used_at: Some(naivedatetime_to_prost_time(api_token.used_at)?),
-            },
+            Token::try_from(api_token)?,
             api_token.id.to_string(),
             secret_key,
         ))
@@ -355,18 +344,7 @@ impl Database {
 
         // Build the response message
         Ok(GetApiTokenResponse {
-            token: Some(Token {
-                id: api_token.id.to_string(),
-                name: api_token.name.unwrap_or_default(),
-                token_type,
-                created_at: Some(naivedatetime_to_prost_time(api_token.created_at)?),
-                expires_at: expires_at_time,
-                collection_id: option_to_string(api_token.collection_id).unwrap_or_default(),
-                project_id: option_to_string(api_token.project_id).unwrap_or_default(),
-                permission: map_permissions_rev(api_token.user_right),
-                is_session: api_token.is_session,
-                used_at: Some(naivedatetime_to_prost_time(api_token.used_at)?),
-            }),
+            token: Some(Token::try_from(api_token)?),
         })
     }
 
@@ -449,24 +427,7 @@ impl Database {
                     };
 
                 // Return gRPC formatted token
-                Ok(Token {
-                    id: api_token.id.to_string(),
-                    // Abomination made by borrow_checker
-                    // if someone knows a better way, feel free to add a PR
-                    name: api_token
-                        .name
-                        .as_ref()
-                        .unwrap_or(&"".to_string())
-                        .to_string(),
-                    token_type,
-                    created_at: Some(naivedatetime_to_prost_time(api_token.created_at)?),
-                    expires_at: expires_at_time,
-                    collection_id: option_to_string(api_token.collection_id).unwrap_or_default(),
-                    project_id: option_to_string(api_token.project_id).unwrap_or_default(),
-                    permission: map_permissions_rev(api_token.user_right),
-                    is_session: api_token.is_session,
-                    used_at: Some(naivedatetime_to_prost_time(api_token.used_at)?),
-                })
+                Ok(Token::try_from(*api_token)?)
             })
             .collect::<Result<Vec<_>, ArunaError>>()?;
 

--- a/src/database/models/auth.rs
+++ b/src/database/models/auth.rs
@@ -49,7 +49,16 @@ pub struct Project {
     pub created_by: diesel_ulid::DieselUlid,
 }
 
-#[derive(Associations, Queryable, Insertable, Identifiable, Debug, Selectable, QueryableByName)]
+#[derive(
+    Associations,
+    Queryable,
+    Insertable,
+    Identifiable,
+    Debug,
+    Selectable,
+    QueryableByName,
+    AsChangeset,
+)]
 #[diesel(table_name = user_permissions)]
 #[diesel(belongs_to(User))]
 #[diesel(belongs_to(Project))]

--- a/src/database/models/auth.rs
+++ b/src/database/models/auth.rs
@@ -125,8 +125,7 @@ impl TryFrom<ApiToken> for Token {
             created_at: Some(naivedatetime_to_prost_time(value.created_at)?),
             expires_at: value
                 .expires_at
-                .map(|v| naivedatetime_to_prost_time(v).ok())
-                .flatten(),
+                .and_then(|v| naivedatetime_to_prost_time(v).ok()),
             collection_id: option_to_string(value.collection_id).unwrap_or_default(),
             project_id: option_to_string(value.project_id).unwrap_or_default(),
             permission: map_permissions_rev(value.user_right),

--- a/src/error.rs
+++ b/src/error.rs
@@ -186,7 +186,7 @@ impl From<AuthorizationError> for ArunaError {
 }
 
 impl From<TryFromSliceError> for ArunaError {
-    fn from(e: TryFromSliceError) -> Self {
+    fn from(_: TryFromSliceError) -> Self {
         ArunaError::TypeConversionError(TypeConversionError::TRYFROMSLICE)
     }
 }

--- a/src/server/services/authz.rs
+++ b/src/server/services/authz.rs
@@ -102,6 +102,8 @@ pub struct Context {
     // All other fields will be ignored, this should only be used for
     // register and the initial creation / deletion of private access tokens
     pub oidc_context: bool,
+    // Allow service accounts
+    pub allow_service_accounts: bool,
 }
 
 /// Implementations for the Authz struct contain methods to create and check
@@ -330,6 +332,7 @@ impl Authz {
                 admin: false,
                 personal: true,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .await
@@ -350,6 +353,7 @@ impl Authz {
                 admin: true,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .await
@@ -372,6 +376,7 @@ impl Authz {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: true,
             }),
         )
         .await
@@ -384,6 +389,7 @@ impl Authz {
         metadata: &MetadataMap,
         project_id: diesel_ulid::DieselUlid,
         user_right: UserRights,
+        allow_service_accounts: bool,
     ) -> Result<diesel_ulid::DieselUlid, ArunaError> {
         self.authorize(
             metadata,
@@ -394,6 +400,7 @@ impl Authz {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts,
             }),
         )
         .await
@@ -418,6 +425,7 @@ impl Authz {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: true,
             }),
         )
         .await
@@ -452,7 +460,7 @@ impl Authz {
             }
             ResourceType::Project => {
                 // Authorize against project
-                self.project_authorize(&metadata, resource_ulid, UserRights::READ)
+                self.project_authorize(&metadata, resource_ulid, UserRights::READ, true)
                     .await?
             }
             ResourceType::Collection => {

--- a/src/server/services/authz.rs
+++ b/src/server/services/authz.rs
@@ -8,6 +8,7 @@ use crate::error::{ArunaError, AuthorizationError};
 use anyhow::Result;
 use aruna_rust_api::api::storage::models::v1::ResourceType;
 use chrono::prelude::*;
+use diesel_ulid::DieselUlid;
 use dotenv::dotenv;
 use http::Method;
 use jsonwebtoken::{
@@ -315,6 +316,18 @@ impl Authz {
                 Ok((creator_uuid, Some(api_token)))
             }
         }
+    }
+
+    /// This function authorizes a user
+    pub async fn authorize_for_service_account(
+        &self,
+        metadata: &MetadataMap,
+        svc_account_id: &DieselUlid,
+    ) -> Result<(), ArunaError> {
+        let token_uuid = self.validate_and_query_token_from_md(metadata).await?;
+        self.db
+            .validate_user_perm_for_svc_account(&token_uuid, svc_account_id)?;
+        Ok(())
     }
 
     /// This is a wrapper that runs the authorize function with a `personal` context

--- a/src/server/services/collection.rs
+++ b/src/server/services/collection.rs
@@ -62,7 +62,7 @@ impl CollectionService for CollectionServiceImpl {
         // Authorize the request
         let creator_id = self
             .authz
-            .project_authorize(request.metadata(), project_id, UserRights::WRITE)
+            .project_authorize(request.metadata(), project_id, UserRights::WRITE, true)
             .await?;
 
         // Execute request in spawn_blocking task to prevent blocking the API server
@@ -208,6 +208,7 @@ impl CollectionService for CollectionServiceImpl {
                 diesel_ulid::DieselUlid::from_str(&request.get_ref().project_id)
                     .map_err(|_| ArunaError::TypeConversionError(TypeConversionError::UUID))?,
                 UserRights::READ,
+                true,
             )
             .await?;
 

--- a/src/server/services/internal_authorize.rs
+++ b/src/server/services/internal_authorize.rs
@@ -108,12 +108,12 @@ impl InternalAuthorizeService for InternalAuthorizeServiceImpl {
                     ResourceAction::Append => false,      // Invalid type/action combination
                     ResourceAction::Update | ResourceAction::Delete => self
                         .authz
-                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::ADMIN)
+                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::ADMIN, true)
                         .await
                         .is_ok(),
                     ResourceAction::Read => self
                         .authz
-                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::READ)
+                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::READ, true)
                         .await
                         .is_ok(),
                 },
@@ -121,7 +121,7 @@ impl InternalAuthorizeService for InternalAuthorizeServiceImpl {
                     ResourceAction::Unspecified => false, // This arm should never be processed
                     ResourceAction::Create => self
                         .authz
-                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::WRITE)
+                        .project_authorize(&grpc_metadata, resource_ulid, UserRights::WRITE, true)
                         .await
                         .is_ok(),
                     ResourceAction::Append => false, // Invalid type/action combination

--- a/src/server/services/internal_proxy_notifier.rs
+++ b/src/server/services/internal_proxy_notifier.rs
@@ -362,6 +362,7 @@ impl InternalProxyNotifierService for InternalProxyNotifierServiceImpl {
                         admin: false,
                         personal: false,
                         oidc_context: false,
+                        allow_service_accounts: true,
                     },
                 )?;
 

--- a/src/server/services/object.rs
+++ b/src/server/services/object.rs
@@ -186,6 +186,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )
             .await?
@@ -944,6 +945,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )
             .await?
@@ -1018,6 +1020,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )
             .await?
@@ -1103,6 +1106,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )
             .await?
@@ -1187,6 +1191,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     personal: false,
                     oidc_context: false,
+                    allow_service_accounts: true,
                 },
             )
             .await?
@@ -1368,6 +1373,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     oidc_context: false,
                     personal: false,
+                    allow_service_accounts: true,
                 }),
             )
             .await?
@@ -1440,6 +1446,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     oidc_context: false,
                     personal: false,
+                    allow_service_accounts: true,
                 }),
             )
             .await?
@@ -1540,6 +1547,7 @@ impl ObjectService for ObjectServiceImpl {
                     admin: false,
                     oidc_context: false,
                     personal: false,
+                    allow_service_accounts: true,
                 }),
             )
             .await?
@@ -1873,6 +1881,7 @@ impl ObjectService for ObjectServiceImpl {
                     &grpc_metadata,
                     project_uuid,     // This is the project uuid context for the object
                     UserRights::READ, // User needs at least read permission to get ids
+                    true,
                 )
                 .await?;
         }

--- a/src/server/services/project.rs
+++ b/src/server/services/project.rs
@@ -110,7 +110,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize the request
         let _user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::ADMIN)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::ADMIN,
+                false,
+            )
             .await?;
 
         // Add user to project
@@ -148,7 +153,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let _user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::READ)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::READ,
+                true,
+            )
             .await?;
 
         // Execute request and return response
@@ -212,7 +222,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let _user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::ADMIN)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::ADMIN,
+                false,
+            )
             .await?;
 
         // Try to delete project
@@ -280,7 +295,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::ADMIN)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::ADMIN,
+                true,
+            )
             .await?;
 
         // Create project
@@ -348,7 +368,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::ADMIN)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::ADMIN,
+                false,
+            )
             .await?;
 
         // Execute request and return response
@@ -385,7 +410,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let _admin_user = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::READ)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::READ,
+                true,
+            )
             .await?;
 
         // Execute request and return response
@@ -423,7 +453,7 @@ impl ProjectService for ProjectServiceImpl {
 
         // Authorize user
         self.authz
-            .project_authorize(request.metadata(), project_uuid, UserRights::READ)
+            .project_authorize(request.metadata(), project_uuid, UserRights::READ, true)
             .await?;
 
         // Execute request and return response
@@ -466,7 +496,12 @@ impl ProjectService for ProjectServiceImpl {
         // Authorize user
         let user_id = self
             .authz
-            .project_authorize(request.metadata(), parsed_project_id, UserRights::ADMIN)
+            .project_authorize(
+                request.metadata(),
+                parsed_project_id,
+                UserRights::ADMIN,
+                false,
+            )
             .await?;
 
         // Execute request and return response

--- a/src/server/services/service_account.rs
+++ b/src/server/services/service_account.rs
@@ -259,26 +259,98 @@ impl ServiceAccountService for ServiceAccountServiceImpl {
     /// Deletes one service account token by ID
     async fn delete_service_account_token(
         &self,
-        _request: tonic::Request<DeleteServiceAccountTokenRequest>,
+        request: tonic::Request<DeleteServiceAccountTokenRequest>,
     ) -> Result<tonic::Response<DeleteServiceAccountTokenResponse>, tonic::Status> {
-        todo!()
+        log::info!("Received DeleteServiceAccountTokenRequest.");
+        log::debug!("{}", format_grpc_request(&request));
+
+        // Parse the project Uuid
+        let parse_svc_account_id =
+            diesel_ulid::DieselUlid::from_str(&request.get_ref().svc_account_id)
+                .map_err(ArunaError::from)?;
+
+        // Authorize that this user is admin in the svc account project
+        self.authz
+            .authorize_for_service_account(request.metadata(), &parse_svc_account_id)
+            .await?;
+
+        let database_clone = self.database.clone();
+        let response = Response::new(
+            task::spawn_blocking(move || {
+                database_clone.delete_service_account_token(request.into_inner())
+            })
+            .await
+            .map_err(ArunaError::from)??,
+        );
+
+        log::info!("Sending DeleteServiceAccountTokenResponse back to client.");
+        log::debug!("{}", format_grpc_response(&response));
+        return Ok(response);
     }
     /// DeleteServiceAccountTokens
     ///
     /// Deletes all service account tokens
     async fn delete_service_account_tokens(
         &self,
-        _request: tonic::Request<DeleteServiceAccountTokensRequest>,
+        request: tonic::Request<DeleteServiceAccountTokensRequest>,
     ) -> Result<tonic::Response<DeleteServiceAccountTokensResponse>, tonic::Status> {
-        todo!()
+        log::info!("Received DeleteServiceAccountTokensRequest.");
+        log::debug!("{}", format_grpc_request(&request));
+
+        // Parse the project Uuid
+        let parse_svc_account_id =
+            diesel_ulid::DieselUlid::from_str(&request.get_ref().svc_account_id)
+                .map_err(ArunaError::from)?;
+
+        // Authorize that this user is admin in the svc account project
+        self.authz
+            .authorize_for_service_account(request.metadata(), &parse_svc_account_id)
+            .await?;
+
+        let database_clone = self.database.clone();
+        let response = Response::new(
+            task::spawn_blocking(move || {
+                database_clone.delete_service_account_tokens(request.into_inner())
+            })
+            .await
+            .map_err(ArunaError::from)??,
+        );
+
+        log::info!("Sending DeleteServiceAccountTokensResponse back to client.");
+        log::debug!("{}", format_grpc_response(&response));
+        return Ok(response);
     }
     /// DeleteServiceAccount
     ///
     /// Deletes a service account (by id)
     async fn delete_service_account(
         &self,
-        _request: tonic::Request<DeleteServiceAccountRequest>,
+        request: tonic::Request<DeleteServiceAccountRequest>,
     ) -> Result<tonic::Response<DeleteServiceAccountResponse>, tonic::Status> {
-        todo!()
+        log::info!("Received DeleteServiceAccountRequest.");
+        log::debug!("{}", format_grpc_request(&request));
+
+        // Parse the project Uuid
+        let parse_svc_account_id =
+            diesel_ulid::DieselUlid::from_str(&request.get_ref().svc_account_id)
+                .map_err(ArunaError::from)?;
+
+        // Authorize that this user is admin in the svc account project
+        self.authz
+            .authorize_for_service_account(request.metadata(), &parse_svc_account_id)
+            .await?;
+
+        let database_clone = self.database.clone();
+        let response = Response::new(
+            task::spawn_blocking(move || {
+                database_clone.delete_service_account(request.into_inner())
+            })
+            .await
+            .map_err(ArunaError::from)??,
+        );
+
+        log::info!("Sending DeleteServiceAccountResponse back to client.");
+        log::debug!("{}", format_grpc_response(&response));
+        return Ok(response);
     }
 }

--- a/src/server/services/user.rs
+++ b/src/server/services/user.rs
@@ -303,6 +303,7 @@ impl UserService for UserServiceImpl {
                         map_permissions(request.get_ref().permission()).ok_or_else(|| {
                             ArunaError::InvalidRequest("Can not parse permissions".to_string())
                         })?,
+                        false,
                     )
                     .await?;
             }

--- a/tests/b1_authz_test.rs
+++ b/tests/b1_authz_test.rs
@@ -880,6 +880,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: true,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -897,6 +898,7 @@ fn get_checked_user_id_from_token_test() {
             admin: true,
             personal: false,
             oidc_context: false,
+            allow_service_accounts: false,
         }),
     );
     assert!(res.is_err());
@@ -911,6 +913,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -926,6 +929,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -941,6 +945,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -956,6 +961,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: false,
                 personal: true,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -970,6 +976,7 @@ fn get_checked_user_id_from_token_test() {
             admin: false,
             personal: true,
             oidc_context: false,
+            allow_service_accounts: false,
         }),
     );
     assert!(res.is_err());
@@ -985,6 +992,7 @@ fn get_checked_user_id_from_token_test() {
                 admin: false,
                 personal: false,
                 oidc_context: false,
+                allow_service_accounts: false,
             }),
         )
         .unwrap();
@@ -999,6 +1007,7 @@ fn get_checked_user_id_from_token_test() {
             admin: false,
             personal: false,
             oidc_context: false,
+            allow_service_accounts: false,
         }),
     );
     assert!(res.is_err());
@@ -1012,6 +1021,7 @@ fn get_checked_user_id_from_token_test() {
             admin: false,
             personal: false,
             oidc_context: false,
+            allow_service_accounts: false,
         }),
     );
     assert!(res.is_err());


### PR DESCRIPTION
This PR builds on top of PR #90 . It adds the long awaited `ServiceAccount` feature.

Service accounts are similar to regular users but have some restrictions:

- Service accounts are always bound to exactly one project and cannot be added to other projects
- SAs are managed via a separate API that has a similar interface as the user equivalent but can be called as `Project::ADMIN`
- Service accounts can do the same things as regular users with the exception user management requests, these are (for now) "real" user only.

This PR implements all necessary API and DB requests that make it possible to create, update and manage service accounts by Project Admins. The API should be treated as BETA for now.

The PR also adds some optimizations in the ApiToken <-> gRPC Token handling by introducing a `TryFrom` implementation, this allows us to remove some token conversion boilerplate from `crud/user.rs`

Fixes: https://github.com/ArunaStorage/ArunaServer/issues/38