### PR TITLE
Basic NotificationsHandler and startup

### DIFF
--- a/src/auth/token_handler.rs
+++ b/src/auth/token_handler.rs
@@ -311,7 +311,9 @@ impl TokenHandler {
         // Check if pubkey is from ArunaServer or Dataproxy.
         let (_, dec_key) = match cached_key {
             PubKey::Server(key) => key,
-            PubKey::DataProxy((_, _, _)) => return Err(anyhow::anyhow!("Token not signed from ArunaServer")),
+            PubKey::DataProxy((_, _, _)) => {
+                return Err(anyhow::anyhow!("Token not signed from ArunaServer"))
+            }
         };
 
         // Decode claims with pubkey
@@ -340,8 +342,7 @@ impl TokenHandler {
     async fn validate_dataproxy_token(
         &self,
         token: &str,
-    ) 
-    -> Result<(
+    ) -> Result<(
         DieselUlid,
         Option<DieselUlid>,
         Vec<(DieselUlid, DbPermissionLevel)>,

--- a/src/caching/mod.rs
+++ b/src/caching/mod.rs
@@ -1,2 +1,3 @@
 pub mod cache;
+pub mod notifications_handler;
 pub mod structs;

--- a/src/caching/notifications_handler.rs
+++ b/src/caching/notifications_handler.rs
@@ -1,0 +1,225 @@
+use std::{str::FromStr, sync::Arc};
+
+use anyhow::bail;
+use aruna_rust_api::api::{
+    notification::services::v2::{
+        anouncement_event::EventVariant as AnnEventVariant, event_message::MessageVariant,
+        AnouncementEvent, EventVariant, ResourceEvent, UserEvent,
+    },
+    storage::models::v2::generic_resource,
+};
+use async_nats::jetstream::consumer::{DeliverPolicy, PushConsumer};
+use diesel_ulid::DieselUlid;
+use futures::StreamExt;
+
+use crate::{
+    database::{
+        connection::Database,
+        crud::CrudDb,
+        dsls::{object_dsl::Object, user_dsl::User},
+    },
+    notification::natsio_handler::NatsIoHandler,
+    utils::grpc_utils::checksum_resource,
+};
+
+use super::cache::Cache;
+
+pub struct NotificationHandler {
+    database: Arc<Database>,
+    cache: Arc<Cache>,
+    natsio_handler: Arc<NatsIoHandler>,
+    stream_consumer: PushConsumer,
+}
+
+// Nats.io handler direkt
+// Message stream?
+impl NotificationHandler {
+    ///ToDo: Rust Doc
+    pub async fn new(
+        database: Arc<Database>,
+        cache: Arc<Cache>,
+        natsio_handler: Arc<NatsIoHandler>,
+    ) -> anyhow::Result<Self> {
+        // Create push consumer for all notifications
+        let myself_id = DieselUlid::generate(); //ToDo: Replace with istance id
+        let (consumer_id, _) = natsio_handler
+            .create_push_consumer(myself_id, "AOS.>".to_string(), DeliverPolicy::All, true)
+            .await?;
+
+        // Fetch push consumer from stream
+        let push_consumer = natsio_handler
+            .get_push_consumer(consumer_id.to_string())
+            .await?;
+
+        // Async move the consumer listening
+        let mut messages = push_consumer.messages().await?;
+        let cache_clone = cache.clone();
+        let database_clone = database.clone();
+        let _ = tokio::spawn(async move {
+            loop {
+                if let Some(Ok(nats_message)) = messages.next().await {
+                    log::debug!("got message {:?}", nats_message);
+
+                    let msg_variant = match serde_json::from_slice(
+                        nats_message.message.payload.to_vec().as_slice(),
+                    ) {
+                        Ok(variant) => variant,
+                        Err(err) => {
+                            return Err::<MessageVariant, anyhow::Error>(anyhow::anyhow!(err))
+                        }
+                    };
+
+                    // Update cache
+                    NotificationHandler::update_resource_cache(
+                        msg_variant,
+                        cache_clone.clone(),
+                        database_clone.clone(),
+                    )
+                    .await?;
+                }
+            }
+        })
+        .await?;
+
+        // Return
+        Ok(NotificationHandler {
+            database,
+            cache,
+            natsio_handler,
+            stream_consumer: push_consumer,
+        })
+    }
+
+    ///ToDo: Rust Doc
+    async fn update_resource_cache(
+        message: MessageVariant,
+        cache: Arc<Cache>,
+        database: Arc<Database>,
+    ) -> anyhow::Result<()> {
+        match message {
+            MessageVariant::ResourceEvent(event) => {
+                process_resource_event(event, cache, database).await?
+            }
+            MessageVariant::UserEvent(event) => {
+                process_user_event(event, cache, database).await?;
+            }
+
+            MessageVariant::AnnouncementEvent(event) => {
+                process_announcement_event(event)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/* -------------- Helper -------------- */
+async fn process_resource_event(
+    resource_event: ResourceEvent,
+    cache: Arc<Cache>,
+    database: Arc<Database>,
+) -> anyhow::Result<()> {
+    if let Some(resource) = resource_event.resource {
+        // Extract resource id
+        let resource_ulid = DieselUlid::from_str(&resource.resource_id)?;
+
+        // Process cache
+        if let Some(variant) = EventVariant::from_i32(resource_event.event_variant) {
+            match variant {
+                EventVariant::Unspecified => bail!("Unspecified event variant not allowed"),
+                EventVariant::Created | EventVariant::Updated => {
+                    if let Some(object_plus) = cache.get_object(&resource_ulid) {
+                        // Convert to proto and compare checksum
+                        let proto_resource: generic_resource::Resource =
+                            object_plus.clone().try_into()?;
+                        let proto_checksum = checksum_resource(proto_resource)?;
+
+                        if !(proto_checksum == resource.checksum) {
+                            // Things that should not happen with a 'Created' event ...
+                            cache.update_object(&resource_ulid, object_plus);
+                        }
+                    } else {
+                        // Fetch object with relations from database and put into cache
+                        let client = database.get_client().await?;
+                        let object_plus =
+                            Object::get_object_with_relations(&resource_ulid, &client).await?;
+
+                        cache.object_cache.insert(resource_ulid, object_plus);
+                    }
+                }
+                EventVariant::Available => {
+                    todo!("Ignore or set resource available in cache")
+                }
+                EventVariant::Deleted => {
+                    // Just delete resource from cache
+                    //  Or set status to deleted?
+                }
+            }
+        } else {
+            // Return error if variant is None
+            bail!("Resource event variant missing")
+        }
+    } else {
+        // Return error
+        bail!("Resource event resource missing")
+    }
+
+    Ok(())
+}
+
+async fn process_user_event(
+    user_event: UserEvent,
+    cache: Arc<Cache>,
+    database: Arc<Database>,
+) -> anyhow::Result<()> {
+    // Extract user id
+    let user_ulid = DieselUlid::from_str(&user_event.user_id)?;
+
+    // Process cache
+    if let Some(variant) = EventVariant::from_i32(user_event.event_variant) {
+        match variant {
+            EventVariant::Unspecified => bail!("Unspecified user event variant not allowed"),
+            EventVariant::Created => {
+                // Check if user already exists
+                if let Some(user) = cache.get_user(&user_ulid) {
+                    // Convert to proto and compare checksum
+                } else {
+                    // Fetch user from database and add to cache
+                    let client = database.get_client().await?;
+                    if let Some(user) = User::get(user_ulid, &client).await? {
+                        cache.add_user(user_ulid, user)
+                    } else {
+                        bail!("User does not exist")
+                    }
+                }
+            }
+            EventVariant::Available => todo!(),
+            EventVariant::Updated => todo!(),
+            EventVariant::Deleted => todo!(),
+        }
+    } else {
+        // Return error if variant is None
+        bail!("User event variant missing")
+    }
+
+    Ok(())
+}
+
+fn process_announcement_event(announcement_event: AnouncementEvent) -> anyhow::Result<()> {
+    if let Some(variant) = announcement_event.event_variant {
+        match variant {
+            AnnEventVariant::NewDataProxyId(_) => unimplemented!("?"),
+            AnnEventVariant::RemoveDataProxyId(_) => unimplemented!("?"),
+            AnnEventVariant::UpdateDataProxyId(_) => unimplemented!("?"),
+            AnnEventVariant::NewPubkey(_) => unimplemented!("Refresh pubkey cache"),
+            AnnEventVariant::RemovePubkey(_) => unimplemented!("Refresh pubkey cache"),
+            AnnEventVariant::Downtime(_) => {
+                unimplemented!("Prepare for downtime. Degradation or something ...")
+            }
+            AnnEventVariant::Version(_) => unimplemented!("Ignore"),
+        }
+    } else {
+        // Return error if variant is None
+        bail!("Announcement event variant missing")
+    }
+}

--- a/src/database/dsls/pub_key_dsl.rs
+++ b/src/database/dsls/pub_key_dsl.rs
@@ -1,6 +1,5 @@
 use crate::database::crud::{CrudDb, PrimaryKey};
 use anyhow::Result;
-use aruna_rust_api::api::storage::services::v2::Pubkey;
 use diesel_ulid::DieselUlid;
 use postgres_from_row::FromRow;
 use tokio_postgres::Client;

--- a/src/database/dsls/pub_key_dsl.rs
+++ b/src/database/dsls/pub_key_dsl.rs
@@ -72,26 +72,17 @@ impl PubKey {
         pubkey: &str,
         client: &Client,
     ) -> Result<PubKey> {
-        let row = if let Some(endpoint_id) = proxy {
-            let query = "
+        // Define prepared SQL query with parameters
+        let query = "
             INSERT INTO pub_keys (proxy, pubkey) 
               VALUES ($1, $2) ON CONFLICT DO NOTHING 
             RETURNING id, proxy, pubkey;";
-            let prepared = client.prepare(query).await?;
+        let prepared = client.prepare(query).await?;
 
-            client
-                .query_one(&prepared, &[&endpoint_id, &pubkey])
-                .await?
-        } else {
-            let query = "
-            INSERT INTO pub_keys (pubkey) 
-              VALUES ($1) ON CONFLICT DO NOTHING 
-            RETURNING id, proxy, pubkey;";
-            let prepared = client.prepare(query).await?;
+        // Execute prepared statement
+        let row = client.query_one(&prepared, &[&proxy, &pubkey]).await?;
 
-            client.query_one(&prepared, &[&pubkey]).await?
-        };
-
+        // Return inserted pubkey
         Ok(PubKey::from_row(&row))
     }
 }

--- a/src/grpc/notification.rs
+++ b/src/grpc/notification.rs
@@ -116,7 +116,7 @@ impl EventNotificationService for NotificationServiceImpl {
         } else {
             tonic_internal!(
                 self.natsio_handler
-                    .create_event_consumer(EventType::All, deliver_policy)
+                    .create_event_consumer(event_type, deliver_policy)
                     .await,
                 "Consumer creation failed"
             )

--- a/src/grpc/notification.rs
+++ b/src/grpc/notification.rs
@@ -101,10 +101,10 @@ impl EventNotificationService for NotificationServiceImpl {
         // Consumer creation depending on request token source
         let (consumer_id, consumer_config) = if is_proxy {
             let consumer_name = DieselUlid::generate(); // Some random id as name
-            let consumer_subject = generate_endpoint_subject(&user_id); // user id is endpoint id
+            let consumer_subject = generate_endpoint_subject(&user_id);
             tonic_internal!(
                 self.natsio_handler
-                    .create_push_consumer(
+                    .create_internal_consumer(
                         consumer_name,
                         consumer_subject,
                         DeliverPolicy::All,

--- a/src/grpc/notification.rs
+++ b/src/grpc/notification.rs
@@ -1,6 +1,8 @@
 use crate::auth::permission_handler::PermissionHandler;
 use crate::auth::structs::Context;
 use crate::caching::cache::Cache;
+use crate::database::enums::ObjectType;
+use crate::notification::utils::generate_endpoint_subject;
 use crate::{database::enums::DbPermissionLevel, middlelayer::db_handler::DatabaseHandler};
 use aruna_rust_api::api::notification::services::v2::{
     create_stream_consumer_request::{StreamType, Target},
@@ -11,6 +13,7 @@ use aruna_rust_api::api::notification::services::v2::{
     EventMessage, GetEventMessageBatchRequest, GetEventMessageBatchResponse,
     GetEventMessageBatchStreamRequest, GetEventMessageBatchStreamResponse, ResourceTarget,
 };
+use aruna_rust_api::api::storage::models::v2::ResourceVariant;
 use async_nats::jetstream::{consumer::DeliverPolicy, Message};
 use diesel_ulid::DieselUlid;
 use std::str::FromStr;
@@ -55,8 +58,7 @@ impl EventNotificationService for NotificationServiceImpl {
         request: tonic::Request<CreateStreamConsumerRequest>,
     ) -> Result<Response<CreateStreamConsumerResponse>, Status> {
         // Log some stuff
-        log::info!("Received CreateStreamConsumerRequest.");
-        log::debug!("{:?}", &request);
+        log_received!(&request);
 
         // Consume gRPC request into its parts
         let (request_metadata, _, inner_request) = request.into_parts();
@@ -67,32 +69,21 @@ impl EventNotificationService for NotificationServiceImpl {
             "Token extraction failed"
         );
 
-        // Evaluate fitting context and check permissions
-        let perm_context = match inner_request
+        // Extract target from inner request
+        let consumer_target = inner_request
             .target
-            .ok_or_else(|| Status::invalid_argument("Missing context"))?
-        {
-            Target::Resource(ResourceTarget {
-                resource_id,
-                resource_variant: _,
-            }) => Context::res_ctx(
-                tonic_invalid!(
-                    DieselUlid::from_str(&resource_id),
-                    "Invalid resource id format"
-                ),
-                DbPermissionLevel::READ,
-                true,
-            ),
-            Target::User(user_id) => Context::user_ctx(
-                tonic_invalid!(DieselUlid::from_str(&user_id), "Invalid user"),
-                DbPermissionLevel::READ,
-            ),
-            Target::Anouncements(_) => Context::default(),
-            Target::All(_) => Context::proxy(),
-        };
-        let user_id = tonic_auth!(
+            .ok_or_else(|| Status::invalid_argument("Missing target context"))?;
+
+        // Evaluate permission context and event type from consumer target
+        let (perm_context, event_type) = extract_context_event_type_from_target(
+            consumer_target,
+            inner_request.include_subresources,
+        )?;
+
+        // Check permission for evaluated permission context
+        let (user_id, _, is_proxy) = tonic_auth!(
             self.authorizer
-                .check_permissions(&token, vec![perm_context])
+                .check_permissions_verbose(&token, vec![perm_context])
                 .await,
             "Permission denied"
         );
@@ -104,21 +95,35 @@ impl EventNotificationService for NotificationServiceImpl {
                 "Stream type conversion failed"
             )
         } else {
-            DeliverPolicy::All
+            DeliverPolicy::All // Default
         };
 
-        // Create stream consumer in Nats.io
-        let (consumer_id, consumer_config) = tonic_internal!(
-            self.natsio_handler
-                .create_event_consumer(EventType::All, deliver_policy)
-                .await,
-            "Consumer creation failed"
-        );
+        // Consumer creation depending on request token source
+        let (consumer_id, consumer_config) = if is_proxy {
+            let consumer_name = DieselUlid::generate(); // Some random id as name
+            let consumer_subject = generate_endpoint_subject(&user_id); // user id is endpoint id
+            tonic_internal!(
+                self.natsio_handler.create_push_consumer(
+                    consumer_name,
+                    consumer_subject,
+                    DeliverPolicy::All,
+                    false,
+                ),
+                "Consumer creation failed"
+            )
+        } else {
+            tonic_internal!(
+                self.natsio_handler
+                    .create_event_consumer(EventType::All, deliver_policy)
+                    .await,
+                "Consumer creation failed"
+            )
+        };
 
         // Create stream consumer in database
         let stream_consumer = StreamConsumer {
-            id: DieselUlid::generate(),
-            user_id: Some(user_id),
+            id: consumer_id,
+            user_id: if is_proxy { None } else { Some(user_id) },
             config: postgres_types::Json(consumer_config),
         };
 
@@ -140,13 +145,10 @@ impl EventNotificationService for NotificationServiceImpl {
         }
 
         // Create gRPC response
-        let grpc_response = Response::new(CreateStreamConsumerResponse {
+        let response = CreateStreamConsumerResponse {
             stream_consumer: consumer_id.to_string(),
-        });
-
-        log::info!("Sending CreateStreamConsumerResponse back to client.");
-        log::debug!("{:?}", &grpc_response);
-        return Ok(grpc_response);
+        };
+        return_with_log!(response);
     }
 
     /// Fetch messages from an existing stream group.
@@ -352,8 +354,9 @@ impl EventNotificationService for NotificationServiceImpl {
             "Event stream handler creation failed"
         );
 
-        // Send messages in batches (if present)
-        let cloned_reply_signing_secret = "Move this into NatsIoHandler?".to_string();
+        // Send messages in batches if present
+        //ToDo: Push Consumer ...? Create ephemeral in EventStreamHndler
+        let cloned_reply_signing_secret = self.natsio_handler.reply_secret.clone();
         tokio::spawn(async move {
             loop {
                 let nats_messages = match handler.get_event_consumer_messages(batch_size).await {
@@ -366,7 +369,7 @@ impl EventNotificationService for NotificationServiceImpl {
                 };
 
                 let mut proto_messages = Vec::new();
-                //ToDo: Conversion from Nats.io to api::EventMessage
+                // Conversion from Nats.io to api::EventMessage
                 for nats_message in nats_messages.into_iter() {
                     // Convert Nats.io message to proto message
                     let event_message =
@@ -509,7 +512,6 @@ impl EventNotificationService for NotificationServiceImpl {
 
         let transaction =
             tonic_internal!(client.transaction().await, "Transaction creation failed");
-
         let transaction_client = transaction.client();
 
         // Fetch stream consumer to check permissions against user_id
@@ -583,6 +585,47 @@ fn convert_stream_type(stream_type: StreamType) -> anyhow::Result<DeliverPolicy>
             start_sequence: info.sequence,
         }),
     }
+}
+
+fn extract_context_event_type_from_target(
+    target: Target,
+    with_subresources: bool,
+) -> Result<(Context, EventType), Status> {
+    Ok(match target {
+        Target::Resource(ResourceTarget {
+            resource_id,
+            resource_variant,
+        }) => {
+            let variant =
+                ResourceVariant::from_i32(resource_variant).ok_or(Status::invalid_argument(""))?;
+            let variant_type =
+                ObjectType::try_from(variant).map_err(|_| Status::invalid_argument(""))?;
+            let event_type = EventType::Resource((resource_id, variant_type, with_subresources));
+
+            let context = Context::res_ctx(
+                tonic_invalid!(
+                    DieselUlid::from_str(&resource_id),
+                    "Invalid resource id format"
+                ),
+                DbPermissionLevel::READ,
+                true,
+            );
+
+            (context, event_type)
+        }
+        Target::User(user_id) => {
+            let event_type = EventType::User(user_id);
+
+            let context = Context::user_ctx(
+                tonic_invalid!(DieselUlid::from_str(&user_id), "Invalid user id format"),
+                DbPermissionLevel::READ,
+            );
+
+            (context, event_type)
+        }
+        Target::Anouncements(_) => (Context::default(), EventType::Announcement(None)),
+        Target::All(_) => (Context::proxy(), EventType::All),
+    })
 }
 
 ///ToDo: Rust Doc

--- a/src/grpc/users.rs
+++ b/src/grpc/users.rs
@@ -448,7 +448,7 @@ impl UserService for UserServiceImpl {
 
         // Check empty context if is registered user
         let token = tonic_auth!(get_token_from_md(&metadata), "Token authentication error");
-        let (user_id, maybe_token) = tonic_auth!(
+        let (user_id, maybe_token, _) = tonic_auth!(
             self.authorizer
                 .check_permissions_verbose(&token, vec![Context::default()])
                 .await,
@@ -537,7 +537,7 @@ impl UserService for UserServiceImpl {
 
         // Check empty context if is registered user
         let token = tonic_auth!(get_token_from_md(&metadata), "Token authentication error");
-        let (_, maybe_token) = tonic_auth!(
+        let (_, maybe_token, _) = tonic_auth!(
             self.authorizer
                 .check_permissions_verbose(&token, vec![Context::default()])
                 .await,

--- a/src/notification/natsio_handler.rs
+++ b/src/notification/natsio_handler.rs
@@ -236,6 +236,18 @@ impl NatsIoHandler {
         })
     }
 
+    ///ToDo: Rust Doc
+    async fn get_event_consumer(
+        &self,
+        event_consumer_id: String,
+    ) -> anyhow::Result<Consumer<Config>> {
+        // Try to get consumer from stream
+        Ok(match self.stream.get_consumer(&event_consumer_id).await {
+            Ok(consumer) => consumer,
+            Err(err) => return Err(anyhow::anyhow!(err)),
+        })
+    }
+
     //ToDo: Rust Doc
     pub async fn create_push_consumer(
         &self,

--- a/src/notification/utils.rs
+++ b/src/notification/utils.rs
@@ -1,5 +1,6 @@
 use aruna_rust_api::api::notification::services::v2::{anouncement_event::EventVariant, Reply};
 use base64::{engine::general_purpose, Engine};
+use diesel_ulid::DieselUlid;
 use hmac::{Hmac, Mac};
 use rand::{distributions::Alphanumeric, Rng};
 use sha2::Sha256;
@@ -97,6 +98,11 @@ pub fn generate_announcement_message_subject(event_variant: &EventVariant) -> St
         EventVariant::Downtime(_) => "AOS.ANNOUNCEMENT.DOWNTIME".to_string(),
         EventVariant::Version(_) => "AOS.ANNOUNCEMENT.VERSION".to_string(),
     }
+}
+
+///ToDo: Rust Doc
+pub fn generate_endpoint_subject(endpoint_id: &DieselUlid) -> String {
+    format!("AOS.ENDPOINT.{}", endpoint_id)
 }
 
 ///ToDo: Rust Doc

--- a/src/utils/conversions.rs
+++ b/src/utils/conversions.rs
@@ -21,7 +21,7 @@ use crate::database::{
 };
 use crate::middlelayer::create_request_types::Parent;
 use ahash::RandomState;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use aruna_rust_api::api::storage::models::v2::{
     generic_resource, CustomAttributes, Permission, PermissionLevel, ResourceVariant, Status,
     Token, User as ApiUser, UserAttributes,
@@ -303,6 +303,20 @@ impl From<ObjectType> for ResourceVariant {
             ObjectType::DATASET => ResourceVariant::Dataset,
             ObjectType::OBJECT => ResourceVariant::Object,
         }
+    }
+}
+
+impl TryFrom<ResourceVariant> for ObjectType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ResourceVariant) -> std::result::Result<Self, Self::Error> {
+        Ok(match value {
+            ResourceVariant::Unspecified => bail!("Unspecified resource variant not allowed"),
+            ResourceVariant::Project => ObjectType::PROJECT,
+            ResourceVariant::Collection => ObjectType::COLLECTION,
+            ResourceVariant::Dataset => ObjectType::DATASET,
+            ResourceVariant::Object => ObjectType::OBJECT,
+        })
     }
 }
 

--- a/tests/common/init_db.rs
+++ b/tests/common/init_db.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 
 #[allow(dead_code)]
 pub async fn init_db() -> Database {
-    let database_host = "localhost";
-    let database_name = "test";
+    let database_host = "localhost".to_string();
+    let database_name = "test".to_string();
     let database_port = 5433;
-    let database_user = "yugabyte";
+    let database_user = "yugabyte".to_string();
     Database::new(database_host, database_port, database_name, database_user).unwrap()
     //db.initialize_db().await.unwrap();
 }

--- a/tests/database/pub_keys.rs
+++ b/tests/database/pub_keys.rs
@@ -70,12 +70,12 @@ async fn test_pub_key_serial_auto_incerement() {
     let dummy_pubkey_002 = gen_rand_string();
 
     // Persist dummy keys in database with auto serial increment
-    let dummy_key_001 = PubKey::create_without_id(None, &dummy_pubkey_001, client)
+    let dummy_key_001 = PubKey::create_or_get_without_id(None, &dummy_pubkey_001, client)
         .await
         .unwrap();
 
     // Persist dummy keys in database with auto serial increment
-    let dummy_key_002 = PubKey::create_without_id(None, &dummy_pubkey_002, client)
+    let dummy_key_002 = PubKey::create_or_get_without_id(None, &dummy_pubkey_002, client)
         .await
         .unwrap();
 


### PR DESCRIPTION
This extends the ArunaServer with a basic implementation of NotificationHandling, which will be used to keep the cache up-to-date in the future.

In addition, the ArunaServer receives a basic start-up procedure, which will of course be considerably expanded in the future to ensure complete consistency of the instance after start-up. This will include, for example, a complete synchronisation of the cache against the database for the first time.

## Features:
* Notification handling for cache updates
* Basic startup procedure to start the individual services
    * Only EndpointService available until default Dataproxy is configured

## Todo:
* Cache sync on startup
* ...