### PR TITLE
Search index tests

### DIFF
--- a/src/grpc/search.rs
+++ b/src/grpc/search.rs
@@ -52,7 +52,7 @@ impl SearchService for SearchServiceImpl {
         );
 
         // Check if: 0 < limit <= 100
-        if inner_request.limit <= 0 || inner_request.limit > 100 {
+        if inner_request.limit < 1 || inner_request.limit > 100 {
             return Err(Status::invalid_argument("Limit must be between 1 and 100"));
         }
 

--- a/src/search/meilisearch_client.rs
+++ b/src/search/meilisearch_client.rs
@@ -39,13 +39,13 @@ impl Display for MeilisearchIndexes {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ObjectDocument {
     pub id: DieselUlid,
-    pub resource_type: u8, // 256 should be enough
-    pub resource_status: ObjectStatus,
+    pub object_type: u8, // 256 should be enough
+    pub object_status: ObjectStatus,
     pub name: String,
     pub description: String,
     pub size: i64,             // Yay or nay?
     pub labels: Vec<KeyValue>, // Without specific internal labels
-    pub dataclass: DataClass,
+    pub data_class: DataClass,
     pub created_at: i64, // Converted to UNIX timestamp for filtering/sorting
     pub dynamic: bool,   // Just for the lulz
 }
@@ -65,13 +65,13 @@ impl From<DbObject> for ObjectDocument {
 
         ObjectDocument {
             id: db_object.id,
-            resource_type: db_object.object_type as u8,
-            resource_status: db_object.object_status,
+            object_type: db_object.object_type as u8,
+            object_status: db_object.object_status,
             name: db_object.name,
             description: db_object.description,
             size: db_object.content_len,
             labels: filtered_labels,
-            dataclass: db_object.data_class,
+            data_class: db_object.data_class,
             created_at: db_object.created_at.unwrap_or_default().timestamp(),
             dynamic: db_object.dynamic,
         }
@@ -83,7 +83,7 @@ impl TryFrom<ObjectDocument> for Resource {
     type Error = anyhow::Error;
 
     fn try_from(val: ObjectDocument) -> Result<Self, Self::Error> {
-        Ok(match val.resource_type {
+        Ok(match val.object_type {
             0 => Resource::Project(val.into()),    // ObjectType::PROJECT
             1 => Resource::Collection(val.into()), // ObjectType::COLLECTION
             2 => Resource::Dataset(val.into()),    // ObjectType::DATASET
@@ -116,13 +116,13 @@ impl From<ObjectDocument> for Project {
             key_values: convert_labels_to_proto(object_document.labels),
             relations: vec![],
             stats: None,
-            data_class: object_document.dataclass as i32,
+            data_class: object_document.data_class as i32,
             created_at: Some(Timestamp {
                 seconds: object_document.created_at,
                 nanos: 0,
             }),
             created_by: "".to_string(),
-            status: Into::<ApiStatus>::into(object_document.resource_status) as i32,
+            status: Into::<ApiStatus>::into(object_document.object_status) as i32,
             dynamic: object_document.dynamic,
             endpoints: vec![],
         }
@@ -136,8 +136,8 @@ impl TryFrom<Project> for ObjectDocument {
         // Build and return ObjectDocument
         Ok(ObjectDocument {
             id: DieselUlid::from_str(&project.id)?,
-            resource_type: ObjectType::PROJECT as u8,
-            resource_status: ObjectStatus::try_from(project.status)?,
+            object_type: ObjectType::PROJECT as u8,
+            object_status: ObjectStatus::try_from(project.status)?,
             name: project.name,
             description: project.description,
             size: if let Some(stats) = project.stats {
@@ -146,7 +146,7 @@ impl TryFrom<Project> for ObjectDocument {
                 0
             },
             labels: convert_proto_to_key_value(project.key_values)?,
-            dataclass: DataClass::try_from(project.data_class)?,
+            data_class: DataClass::try_from(project.data_class)?,
             created_at: project.created_at.unwrap_or_default().seconds,
             dynamic: project.dynamic,
         })
@@ -163,13 +163,13 @@ impl From<ObjectDocument> for Collection {
             key_values: convert_labels_to_proto(object_document.labels),
             relations: vec![],
             stats: None,
-            data_class: object_document.dataclass as i32,
+            data_class: object_document.data_class as i32,
             created_at: Some(Timestamp {
                 seconds: object_document.created_at,
                 nanos: 0,
             }),
             created_by: "".to_string(),
-            status: Into::<ApiStatus>::into(object_document.resource_status) as i32,
+            status: Into::<ApiStatus>::into(object_document.object_status) as i32,
             dynamic: object_document.dynamic,
             endpoints: vec![],
         }
@@ -183,8 +183,8 @@ impl TryFrom<Collection> for ObjectDocument {
         // Build and return ObjectDocument
         Ok(ObjectDocument {
             id: DieselUlid::from_str(&collection.id)?,
-            resource_type: ObjectType::COLLECTION as u8,
-            resource_status: ObjectStatus::try_from(collection.status)?,
+            object_type: ObjectType::COLLECTION as u8,
+            object_status: ObjectStatus::try_from(collection.status)?,
             name: collection.name,
             description: collection.description,
             size: if let Some(stats) = collection.stats {
@@ -193,7 +193,7 @@ impl TryFrom<Collection> for ObjectDocument {
                 0
             },
             labels: convert_proto_to_key_value(collection.key_values)?,
-            dataclass: DataClass::try_from(collection.data_class)?,
+            data_class: DataClass::try_from(collection.data_class)?,
             created_at: collection.created_at.unwrap_or_default().seconds,
             dynamic: collection.dynamic,
         })
@@ -210,13 +210,13 @@ impl From<ObjectDocument> for Dataset {
             key_values: convert_labels_to_proto(object_document.labels),
             relations: vec![],
             stats: None,
-            data_class: object_document.dataclass as i32,
+            data_class: object_document.data_class as i32,
             created_at: Some(Timestamp {
                 seconds: object_document.created_at,
                 nanos: 0,
             }),
             created_by: "".to_string(),
-            status: Into::<ApiStatus>::into(object_document.resource_status) as i32,
+            status: Into::<ApiStatus>::into(object_document.object_status) as i32,
             dynamic: object_document.dynamic,
             endpoints: vec![],
         }
@@ -230,8 +230,8 @@ impl TryFrom<Dataset> for ObjectDocument {
         // Build and return ObjectDocument
         Ok(ObjectDocument {
             id: DieselUlid::from_str(&dataset.id)?,
-            resource_type: ObjectType::DATASET as u8,
-            resource_status: ObjectStatus::try_from(dataset.status)?,
+            object_type: ObjectType::DATASET as u8,
+            object_status: ObjectStatus::try_from(dataset.status)?,
             name: dataset.name,
             description: dataset.description,
             size: if let Some(stats) = dataset.stats {
@@ -240,7 +240,7 @@ impl TryFrom<Dataset> for ObjectDocument {
                 0
             },
             labels: convert_proto_to_key_value(dataset.key_values)?,
-            dataclass: DataClass::try_from(dataset.data_class)?,
+            data_class: DataClass::try_from(dataset.data_class)?,
             created_at: dataset.created_at.unwrap_or_default().seconds,
             dynamic: dataset.dynamic,
         })
@@ -257,13 +257,13 @@ impl From<ObjectDocument> for Object {
             key_values: convert_labels_to_proto(object_document.labels),
             relations: vec![],
             content_len: object_document.size,
-            data_class: object_document.dataclass as i32,
+            data_class: object_document.data_class as i32,
             created_at: Some(Timestamp {
                 seconds: object_document.created_at,
                 nanos: 0,
             }),
             created_by: "".to_string(),
-            status: Into::<ApiStatus>::into(object_document.resource_status) as i32,
+            status: Into::<ApiStatus>::into(object_document.object_status) as i32,
             dynamic: false, // Objects are alywas persistent
             hashes: vec![],
             endpoints: vec![],
@@ -278,13 +278,13 @@ impl TryFrom<Object> for ObjectDocument {
         // Build and return ObjectDocument
         Ok(ObjectDocument {
             id: DieselUlid::from_str(&object.id)?,
-            resource_type: ObjectType::OBJECT as u8,
-            resource_status: ObjectStatus::try_from(object.status)?,
+            object_type: ObjectType::OBJECT as u8,
+            object_status: ObjectStatus::try_from(object.status)?,
             name: object.name,
             description: object.description,
             size: object.content_len,
             labels: convert_proto_to_key_value(object.key_values)?,
-            dataclass: DataClass::try_from(object.data_class)?,
+            data_class: DataClass::try_from(object.data_class)?,
             created_at: object.created_at.unwrap_or_default().seconds,
             dynamic: object.dynamic,
         })
@@ -373,15 +373,15 @@ impl MeilisearchClient {
             // Set the filterable attributes of the index
             index
                 .set_filterable_attributes([
-                    "object_type",      // > 2
-                    "object_type_name", // IN [PROJECT, DATASET]
-                    "resource_status",  // Jo
-                    "size",
+                    "object_type", // e.g. object_type = 1 or object_type > 2
+                    //"object_type_name", //e.g. = OBJECT or IN [PROJECT, DATASET]
+                    "object_status", // e.g. = "AVAILABLE" or IN [AVAILABLE, ERROR]
+                    "size",          // e.g. size > 12345
                     "labels.key",
                     "labels.value",
-                    "labels.variant",
-                    "dataclass",
-                    "created_at",
+                    "labels.variant", // e.g. labels.variant = "LABEL"
+                    "data_class",     // e.g. data_class = "PUBLIC"
+                    "created_at",     // e.g. created_at < 1692824072 (2023-08-23T20:54:32+00:00)
                 ])
                 .await?;
 

--- a/src/utils/grpc_utils.rs
+++ b/src/utils/grpc_utils.rs
@@ -147,7 +147,7 @@ pub async fn update_search_index(
     // Remove confidential objects
     let final_updates = index_updates
         .into_iter()
-        .filter(|od| od.resource_type < 3)
+        .filter(|od| od.object_type < 3)
         .collect::<Vec<_>>();
 
     // Update remaining objects in search index

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -1,0 +1,168 @@
+use aruna_rust_api::api::storage::models::v2::generic_resource;
+use aruna_server::{
+    database::{
+        dsls::object_dsl::{KeyValue, KeyValueVariant},
+        enums::{DataClass, ObjectStatus, ObjectType},
+    },
+    search::meilisearch_client::{MeilisearchClient, MeilisearchIndexes, ObjectDocument},
+};
+use chrono::NaiveDateTime;
+use diesel_ulid::DieselUlid;
+use rand::{seq::IteratorRandom, thread_rng, Rng};
+
+mod common;
+
+#[tokio::test]
+async fn search_test() {
+    // Create Meilisearch client
+    let meilisearch_client =
+        MeilisearchClient::new("http://localhost:7700", Some("MASTER_KEY")).unwrap();
+
+    // Create index
+    meilisearch_client
+        .get_or_create_index("objects", Some("id"))
+        .await
+        .unwrap();
+
+    // Generate random index objects
+    let index_documents = (0..10)
+        .into_iter()
+        .map(|_| generate_random_object_document())
+        .collect::<Vec<_>>();
+
+    // Put objects in index
+    meilisearch_client
+        .add_or_update_stuff(index_documents.as_slice(), MeilisearchIndexes::OBJECT)
+        .await
+        .unwrap()
+        .wait_for_completion(&meilisearch_client.client, None, None)
+        .await
+        .unwrap();
+
+    // List index for and check if index contains all created documents
+    let all_documents = meilisearch_client.list_index("objects").await.unwrap();
+/* 
+    for doc in &index_documents {
+        if !(all_documents.contains(doc)) {
+            dbg!(all_documents.len());
+            dbg!(doc);
+        }
+
+        assert!(all_documents.contains(doc))
+    }
+*/
+    
+       index_documents
+           .iter()
+           .for_each(|doc| assert!(all_documents.contains(doc)));
+    
+    // Query some specific stuff without filter/sorting
+    let mut specific_document = index_documents.first().unwrap().to_owned();
+    let document_id = specific_document.id.to_string();
+    let search_query = specific_document.size.to_string();
+
+    let (hits, estimated_total) = meilisearch_client
+        .query_generic_stuff::<ObjectDocument>("objects", &search_query, "", 1000, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(estimated_total, 1);
+
+    // Query some stuff with broken filter
+    let mut query_filter = r#"resource_status IN [AVAILABLE, "ERROR"]"#;
+    let result = meilisearch_client
+        .query_generic_stuff::<ObjectDocument>("objects", "whatev", query_filter, 1000, 0)
+        .await;
+    assert!(result.is_err()); // resource_status is not in the list of filterable attributes
+
+    // Update an index document
+    specific_document.data_class = DataClass::PRIVATE;
+    meilisearch_client
+        .add_or_update_stuff(&[specific_document], MeilisearchIndexes::OBJECT)
+        .await
+        .unwrap()
+        .wait_for_completion(&meilisearch_client.client, None, None)
+        .await
+        .unwrap();
+
+    // Query updated document by unique dataclass
+    query_filter = r#"data_class = PRIVATE"#;
+    let (hits, estimated_total) = meilisearch_client
+        .query_generic_stuff::<ObjectDocument>("objects", "ChatGPT", query_filter, 1000, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(hits.len(), 1);
+    assert_eq!(estimated_total, 1);
+
+    // Remove some index document
+    meilisearch_client
+        .delete_stuff(&[document_id], MeilisearchIndexes::OBJECT)
+        .await
+        .unwrap()
+        .wait_for_completion(&meilisearch_client.client, None, None)
+        .await
+        .unwrap();
+
+    let (hits, estimated_total) = meilisearch_client
+        .query_generic_stuff::<ObjectDocument>("objects", &search_query, "", 1000, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(hits.len(), 0);
+    assert_eq!(estimated_total, 0); // specific document is not in search index anymore
+
+    // Convert all index documents to proto representation
+    for doc in all_documents {
+        generic_resource::Resource::try_from(doc).unwrap();
+    }
+}
+
+fn generate_random_object_document() -> ObjectDocument {
+    let mut rng = thread_rng();
+    let name_parts = vec![
+        "rna", "hyper", "breaking", "sequence", "mapper", "stuff", "creature", "bacteria",
+        "science", "dna", "cdna",
+    ];
+    let project_name = name_parts
+        .into_iter()
+        .choose_multiple(&mut rng, 2)
+        .to_vec()
+        .join("-");
+    let rand_size = rng.gen_range(123..123456789);
+    let hook_run_success = rng.gen_bool(0.5).to_string();
+    let created_at = format!("{}-01-01 23:59:59", rng.gen_range(2001..2023));
+
+    ObjectDocument {
+        id: DieselUlid::generate(),
+        object_type: ObjectType::try_from(rng.gen_range(1..5)).unwrap() as u8,
+        object_status: ObjectStatus::try_from(rng.gen_range(1..6)).unwrap(),
+        name: project_name,
+        description: "ChatGPT should create some hallucinated description of this project."
+            .to_string(),
+        size: rand_size,
+        labels: vec![
+            KeyValue {
+                key: "validated".to_string(),
+                value: hook_run_success.clone(),
+                variant: KeyValueVariant::LABEL,
+            },
+            KeyValue {
+                key: "submitted".to_string(),
+                value: hook_run_success,
+                variant: KeyValueVariant::LABEL,
+            },
+            KeyValue {
+                key: "validate_and_submit".to_string(),
+                value: "fastq;ENA".to_string(),
+                variant: KeyValueVariant::HOOK,
+            },
+        ],
+        data_class: DataClass::PUBLIC,
+        created_at: NaiveDateTime::parse_from_str(&created_at, "%Y-%m-%d %H:%M:%S")
+            .unwrap()
+            .timestamp(),
+        dynamic: rng.gen_bool(0.5).to_string().parse::<bool>().unwrap(),
+    }
+}

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -26,7 +26,6 @@ async fn search_test() {
 
     // Generate random index objects
     let index_documents = (0..10)
-        .into_iter()
         .map(|_| generate_random_object_document())
         .collect::<Vec<_>>();
 
@@ -41,21 +40,11 @@ async fn search_test() {
 
     // List index for and check if index contains all created documents
     let all_documents = meilisearch_client.list_index("objects").await.unwrap();
-/* 
-    for doc in &index_documents {
-        if !(all_documents.contains(doc)) {
-            dbg!(all_documents.len());
-            dbg!(doc);
-        }
 
-        assert!(all_documents.contains(doc))
-    }
-*/
-    
-       index_documents
-           .iter()
-           .for_each(|doc| assert!(all_documents.contains(doc)));
-    
+    index_documents
+        .iter()
+        .for_each(|doc| assert!(all_documents.contains(doc)));
+
     // Query some specific stuff without filter/sorting
     let mut specific_document = index_documents.first().unwrap().to_owned();
     let document_id = specific_document.id.to_string();


### PR DESCRIPTION
Small PR to increase the test coverage and fix small things regarding the search functionality.

## Features:
- Tests to cover basic search functions
- Removed default Meilisearch result limit of 20 hits per search

## Discussion:

What would be a good limit for the maximum number of hits for an individual search? Should it be the maximum that we limit to 100 for external users anyway or do we have the need for more hits internally? Maybe 1.000.000 is a bit too high to start with?