### PR TITLE
Add message deduplication

### DIFF
--- a/src/middlelayer/clone_db_handler.rs
+++ b/src/middlelayer/clone_db_handler.rs
@@ -67,11 +67,17 @@ impl DatabaseHandler {
         // Fetch all object paths for the notification subjects
         for object_plus in objects_plus.values() {
             let object_hierarchies = clone.fetch_object_hierarchies(&client).await?;
+            let block_id = DieselUlid::generate();
 
             // Try to emit object created notification(s)
             if let Err(err) = self
                 .natsio_handler
-                .register_resource_event(object_plus, object_hierarchies, EventVariant::Created)
+                .register_resource_event(
+                    object_plus,
+                    object_hierarchies,
+                    EventVariant::Created,
+                    Some(&block_id),
+                )
                 .await
             {
                 // Log and return error

--- a/src/middlelayer/create_db_handler.rs
+++ b/src/middlelayer/create_db_handler.rs
@@ -125,7 +125,12 @@ impl DatabaseHandler {
         // Try to emit object created notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_with_rel, object_hierarchies, EventVariant::Created)
+            .register_resource_event(
+                &object_with_rel,
+                object_hierarchies,
+                EventVariant::Created,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return

--- a/src/middlelayer/relations_db_handler.rs
+++ b/src/middlelayer/relations_db_handler.rs
@@ -9,6 +9,7 @@ use crate::middlelayer::relations_request_types::{
 use ahash::HashSet;
 use anyhow::Result;
 use aruna_rust_api::api::notification::services::v2::EventVariant;
+use diesel_ulid::DieselUlid;
 use std::sync::Arc;
 
 impl DatabaseHandler {
@@ -68,10 +69,16 @@ impl DatabaseHandler {
 
         for object_plus in &objects_plus {
             let hierarchies = object_plus.object.fetch_object_hierarchies(&client).await?;
+            let block_id = DieselUlid::generate();
 
             if let Err(err) = self
                 .natsio_handler
-                .register_resource_event(object_plus, hierarchies, EventVariant::Updated)
+                .register_resource_event(
+                    object_plus,
+                    hierarchies,
+                    EventVariant::Updated,
+                    Some(&block_id),
+                )
                 .await
             {
                 // Log error, rollback transaction and return

--- a/src/middlelayer/snapshot_db_handler.rs
+++ b/src/middlelayer/snapshot_db_handler.rs
@@ -53,6 +53,7 @@ impl DatabaseHandler {
                         obj,
                         obj.object.fetch_object_hierarchies(&client).await?,
                         EventVariant::Updated,
+                        DieselUlid::generate(), // block_id for deduplication
                     ))
                 }
 
@@ -65,6 +66,7 @@ impl DatabaseHandler {
                         &resource,
                         resource.object.fetch_object_hierarchies(&client).await?,
                         EventVariant::Updated,
+                        DieselUlid::generate(), // block_id for deduplication
                     ),
                     (
                         &result[0],
@@ -73,30 +75,33 @@ impl DatabaseHandler {
                             .fetch_object_hierarchies(&client)
                             .await?,
                         EventVariant::Snapshotted,
+                        DieselUlid::generate(), // block_id for deduplication
                     ),
                 ]
             }
             SnapshotResponse::SnapshotDataset(snapshot) => {
-                //  - Dataset snapshot    -> Old Object updated, New Object snapshotted
+                //  - Dataset snapshot -> Old Object updated, New Object snapshotted
                 vec![
                     (
                         &resource,
                         resource.object.fetch_object_hierarchies(&client).await?,
                         EventVariant::Updated,
+                        DieselUlid::generate(), // block_id for deduplication
                     ),
                     (
                         &result[0],
                         snapshot.dataset.fetch_object_hierarchies(&client).await?,
                         EventVariant::Snapshotted,
+                        DieselUlid::generate(), // block_id for deduplication
                     ),
                 ]
             }
         };
 
-        for (object_plus, hierarchies, event_variant) in emissions {
+        for (object_plus, hierarchies, event_variant, block_id) in emissions {
             if let Err(err) = self
                 .natsio_handler
-                .register_resource_event(object_plus, hierarchies, event_variant)
+                .register_resource_event(object_plus, hierarchies, event_variant, Some(&block_id))
                 .await
             {
                 // Log error, rollback transaction and return

--- a/src/middlelayer/update_db_handler.rs
+++ b/src/middlelayer/update_db_handler.rs
@@ -43,7 +43,12 @@ impl DatabaseHandler {
         // Try to emit object updated notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_plus, hierarchies, EventVariant::Updated)
+            .register_resource_event(
+                &object_plus,
+                hierarchies,
+                EventVariant::Updated,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return
@@ -73,7 +78,12 @@ impl DatabaseHandler {
         // Try to emit object updated notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_plus, hierarchies, EventVariant::Updated)
+            .register_resource_event(
+                &object_plus,
+                hierarchies,
+                EventVariant::Updated,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return
@@ -106,7 +116,12 @@ impl DatabaseHandler {
         // Try to emit object updated notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_plus, hierarchies, EventVariant::Updated)
+            .register_resource_event(
+                &object_plus,
+                hierarchies,
+                EventVariant::Updated,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return
@@ -160,7 +175,12 @@ impl DatabaseHandler {
         // Try to emit object updated notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_plus, hierarchies, EventVariant::Updated)
+            .register_resource_event(
+                &object_plus,
+                hierarchies,
+                EventVariant::Updated,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return
@@ -260,7 +280,12 @@ impl DatabaseHandler {
         // Try to emit object updated notification(s)
         if let Err(err) = self
             .natsio_handler
-            .register_resource_event(&object_plus, hierarchies, EventVariant::Updated)
+            .register_resource_event(
+                &object_plus,
+                hierarchies,
+                EventVariant::Updated,
+                Some(&DieselUlid::generate()), // block_id for deduplication
+            )
             .await
         {
             // Log error, rollback transaction and return
@@ -272,6 +297,7 @@ impl DatabaseHandler {
             Ok((object_plus, flag))
         }
     }
+
     pub async fn finish_object(
         &self,
         request: FinishObjectStagingRequest,

--- a/src/notification/handler.rs
+++ b/src/notification/handler.rs
@@ -28,6 +28,7 @@ pub trait EventHandler {
     async fn register_event(
         &self,
         message_variant: MessageVariant,
+        message_id: Option<&DieselUlid>,
         subject: String,
     ) -> anyhow::Result<()>;
 

--- a/src/notification/utils.rs
+++ b/src/notification/utils.rs
@@ -4,6 +4,7 @@ use diesel_ulid::DieselUlid;
 use hmac::{Hmac, Mac};
 use rand::{distributions::Alphanumeric, Rng};
 use sha2::Sha256;
+use xxhash_rust::xxh3::xxh3_128;
 
 use crate::database::{dsls::object_dsl::Hierarchy, enums::ObjectType};
 
@@ -149,6 +150,11 @@ pub fn parse_event_consumer_subject(subject: &str) -> anyhow::Result<EventType> 
 // ----- Reply Validation -------------------- //
 // ------------------------------------------- //
 type HmacSha256 = Hmac<Sha256>;
+
+///ToDo: Rust Doc
+pub fn calculate_base64_xxhash(payload: &[u8]) -> String {
+    general_purpose::STANDARD.encode(xxh3_128(payload).to_le_bytes())
+}
 
 ///ToDo: Rust Doc
 pub fn calculate_reply_hmac(reply_subject: &str, secret: String) -> Reply {


### PR DESCRIPTION
This adds message deduplication to the integrated notification concept.

Since the hierarchy concept allows the same notification to be sent to a consumer multiple times, it is beneficial to perform internal deduplication. 

If a notification with the same content is sent for several hierarchies of a resource, these notifications are provided with the same ULID in their header (`"block-id": ULID`). This ULID is used to re-identify the message blocks that belong together when a consumer retrieves several of them.

This ensures that each notification within a particular action in the AOS is only delivered once to the user.