### PR TITLE
Extended endpoint removal

### DIFF
--- a/src/auth/issuer_handler.rs
+++ b/src/auth/issuer_handler.rs
@@ -80,8 +80,7 @@ impl Issuer {
             bail!("Only OIDC issuers can refresh JWKS");
         }
         let (decodings_keys, last_updated) = Self::fetch_jwks(
-            &self
-                .pubkey_endpoint
+            self.pubkey_endpoint
                 .as_ref()
                 .ok_or_else(|| anyhow!("Invalid endpoint type"))?,
         )
@@ -122,8 +121,7 @@ impl Issuer {
         let alg = header.alg;
         let mut validation = jsonwebtoken::Validation::new(alg);
         validation.set_audience(audiences);
-        let tokendata =
-            jsonwebtoken::decode::<ArunaTokenClaims>(token, &decoding_key, &validation)?;
+        let tokendata = jsonwebtoken::decode::<ArunaTokenClaims>(token, decoding_key, &validation)?;
         Ok(tokendata.claims)
     }
 }

--- a/src/auth/token_handler.rs
+++ b/src/auth/token_handler.rs
@@ -324,7 +324,7 @@ impl TokenHandler {
 
         // Convert token id if present
         let maybe_token = match &claims.tid {
-            Some(token_id) => Some(DieselUlid::from_str(&token_id)?),
+            Some(token_id) => Some(DieselUlid::from_str(token_id)?),
             None => None,
         };
 
@@ -382,7 +382,7 @@ impl TokenHandler {
 
                             // Convert token id if present
                             let token = match &claims.tid {
-                                Some(token_id) => Some(DieselUlid::from_str(&token_id)?),
+                                Some(token_id) => Some(DieselUlid::from_str(token_id)?),
                                 None => None,
                             };
 

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -66,7 +66,7 @@ impl Cache {
         let cache_clone = cache.clone();
 
         tokio::spawn(async move {
-            while let Some(issuer_name) = issuer_recv.recv().await.ok() {
+            while let Ok(issuer_name) = issuer_recv.recv().await {
                 cache_clone.update_issuer(&issuer_name).await.ok();
             }
         });
@@ -97,7 +97,7 @@ impl Cache {
             .map(|x| {
                 let id = x.id as i32;
                 match PubKeyEnum::try_from(x) {
-                    Ok(e) => Ok((id as i32, e)),
+                    Ok(e) => Ok((id, e)),
                     Err(e) => Err(e),
                 }
             })

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -306,32 +306,6 @@ impl Cache {
         }))
     }
 
-    pub fn remove_endpoint_pubkeys(&self, endpoint_id: &DieselUlid) {
-        self.check_lock();
-        for entry in &self.pubkeys {
-            if let PubKeyEnum::DataProxy((_, _, pubkey_endpoint)) = entry.value() {
-                if endpoint_id == pubkey_endpoint {
-                    self.pubkeys.remove(entry.key());
-                }
-            }
-        }
-    }
-
-    pub fn remove_endpoint_from_resources(&self, endpoint_id: &DieselUlid) {
-        self.check_lock();
-        for entry in &self.object_cache {
-            entry.object.endpoints.0.remove(endpoint_id);
-        }
-    }
-
-    pub fn remove_endpoint_from_users(&self, endpoint_id: &DieselUlid) {
-        self.check_lock();
-        self.user_cache.iter().for_each(|entry| {
-            let val = entry.value();
-            val.attributes.0.trusted_endpoints.remove(endpoint_id);
-        });
-    }
-
     pub fn get_hierarchy(&self, id: &DieselUlid) -> Result<Graph> {
         self.check_lock();
         let init = self
@@ -652,11 +626,8 @@ impl Cache {
 
 #[cfg(test)]
 mod tests {
-    use crate::database::dsls::{user_dsl::UserAttributes, Empty};
-
     use super::*;
     use diesel_ulid::DieselUlid;
-    use postgres_types::Json;
 
     #[tokio::test]
     async fn test_remove_object() {
@@ -679,76 +650,6 @@ mod tests {
             cache.get_object(&object_ulid).unwrap().object.object_status,
             ObjectStatus::DELETED
         );
-    }
-
-    #[tokio::test]
-    async fn test_remove_endpoint_from_users() {
-        let cache = Cache::new();
-
-        // Generate random endpoint id
-        let endpoint_id = DieselUlid::generate();
-        let random_endpoint = DieselUlid::generate();
-
-        // Insert users with trusted_endpoint
-        let user_1 = DieselUlid::generate();
-        cache.add_user(
-            user_1,
-            User {
-                id: user_1,
-                display_name: "user-1".to_string(),
-                email: "test-1@example.com".to_string(),
-                attributes: Json(UserAttributes {
-                    global_admin: false,
-                    service_account: false,
-                    tokens: DashMap::default(),
-                    trusted_endpoints: DashMap::from_iter([
-                        (endpoint_id, Empty {}),
-                        (random_endpoint, Empty {}),
-                    ]),
-                    custom_attributes: vec![],
-                    permissions: DashMap::default(),
-                    external_ids: vec![],
-                }),
-                active: true,
-            },
-        );
-
-        // Insert users with trusted_endpoint
-        let user_2 = DieselUlid::generate();
-        cache.add_user(
-            user_2,
-            User {
-                id: user_2,
-                display_name: "user-2".to_string(),
-                email: "test-2@example.com".to_string(),
-                attributes: Json(UserAttributes {
-                    global_admin: false,
-                    service_account: false,
-                    tokens: DashMap::default(),
-                    trusted_endpoints: DashMap::from_iter([(endpoint_id, Empty {})]),
-                    custom_attributes: vec![],
-                    permissions: DashMap::default(),
-                    external_ids: vec![],
-                }),
-                active: true,
-            },
-        );
-
-        // Remove endpoint from users
-        cache.remove_endpoint_from_users(&endpoint_id);
-
-        // Fetch user and validate endpoint removal
-        let user_1_upd = cache.get_user(&user_1).unwrap();
-
-        assert_eq!(user_1_upd.attributes.0.trusted_endpoints.len(), 1);
-        assert!(user_1_upd
-            .attributes
-            .0
-            .trusted_endpoints
-            .contains_key(&random_endpoint));
-
-        let user_2_upd = cache.get_user(&user_2).unwrap();
-        assert!(user_2_upd.attributes.0.trusted_endpoints.is_empty())
     }
 
     #[tokio::test]

--- a/src/caching/notifications_handler.rs
+++ b/src/caching/notifications_handler.rs
@@ -277,15 +277,12 @@ async fn process_announcement_event(
                 log::info!("Received NewDataProxyId announcement for: {id}")
             }
             AnnEventVariant::RemoveDataProxyId(id) => {
-                let endpoint_id = DieselUlid::from_str(&id)?;
-                // Remove endpoint pubkeys from cache
-                cache.remove_endpoint_pubkeys(&endpoint_id);
-                // Remove endpoint from all users in cache
-                cache.remove_endpoint_from_users(&endpoint_id);
-                // Remove endpoint from all resources
-                cache.remove_endpoint_from_users(&endpoint_id);
-                //Note: No need to remove pubkeys from database here
-                //      as they are cascade deleted with the endpoint
+                log::info!("Received RemoveDataProxy announcement for: {id}");
+
+                // Removes endpoint from all users/resources in cache with full sync.
+                // As the endpoint was already removed from all users and resources on the database
+                //  level this should reset the cache to full consistency with the current database status.
+                cache.sync_cache(database).await?
             }
             AnnEventVariant::UpdateDataProxyId(id) => {
                 //Note: Endpoint cache currently not implemented

--- a/src/database/dsls/object_dsl.rs
+++ b/src/database/dsls/object_dsl.rs
@@ -242,7 +242,7 @@ impl Object {
             RETURNING *;";
 
         let insert: DashMap<DieselUlid, bool, RandomState> =
-            DashMap::from_iter([(endpoint_id.clone(), full_sync)]);
+            DashMap::from_iter([(*endpoint_id, full_sync)]);
         let prepared = client.prepare(query).await?;
         let row = client
             .query_one(&prepared, &[&Json(insert), object_id])

--- a/src/middlelayer/endpoints_db_handler.rs
+++ b/src/middlelayer/endpoints_db_handler.rs
@@ -1,6 +1,8 @@
 use crate::database::crud::CrudDb;
 use crate::database::dsls::endpoint_dsl::Endpoint;
+use crate::database::dsls::object_dsl::Object;
 use crate::database::dsls::pub_key_dsl::PubKey;
+use crate::database::dsls::user_dsl::User;
 use crate::middlelayer::db_handler::DatabaseHandler;
 use crate::middlelayer::endpoints_request_types::{CreateEP, DeleteEP, GetBy, GetEP};
 
@@ -54,9 +56,21 @@ impl DatabaseHandler {
     }
 
     pub async fn delete_endpoint(&self, request: DeleteEP) -> Result<()> {
-        let client = self.database.get_client().await?;
+        // Open transaction
+        let mut db_client = self.database.get_client().await?;
+        let transaction = db_client.transaction().await?;
+        let transaction_client = transaction.client();
+
+        // Remove endpoint from database
         let id = request.get_id()?;
-        Endpoint::delete_by_id(&id, client.client()).await?;
+        Endpoint::delete_by_id(&id, transaction_client.client()).await?;
+
+        // Remove endpoint from users/resources
+        User::remove_endpoint_from_users(transaction_client, &id).await?;
+        Object::remove_endpoint_from_objects(transaction_client, &id).await?;
+
+        // Commit transaction
+        transaction.commit().await?;
 
         // Emit announcement notification
         if let Err(err) = self

--- a/src/middlelayer/user_db_handler.rs
+++ b/src/middlelayer/user_db_handler.rs
@@ -411,13 +411,9 @@ impl DatabaseHandler {
         if user.attributes.0.external_ids.len() == 1 {
             bail!("Cannot remove last external id");
         }
-        new_attributes.external_ids.retain(|e| {
-            if e.oidc_name != provider_name {
-                true
-            } else {
-                false
-            }
-        });
+        new_attributes
+            .external_ids
+            .retain(|e| e.oidc_name != provider_name);
         let user = User::set_user_attributes(&client, &user_id, Json(new_attributes)).await?;
         self.cache.update_user(&user_id, user.clone());
         Ok(user)

--- a/src/middlelayer/workspace_request_types.rs
+++ b/src/middlelayer/workspace_request_types.rs
@@ -85,7 +85,7 @@ impl CreateWorkspace {
         let endpoints = endpoints.into_iter().map(|id| (id, Empty {}));
         User {
             id: user_id,
-            display_name: format!("SERVICE_ACCOUNT#{}", user_id.to_string()),
+            display_name: format!("SERVICE_ACCOUNT#{}", user_id),
             email: String::new(),
             attributes: Json(UserAttributes {
                 global_admin: false,

--- a/tests/database/objects.rs
+++ b/tests/database/objects.rs
@@ -741,19 +741,13 @@ async fn add_remove_endpoint_test() {
     user.create(client).await.unwrap();
 
     let mut project = test_utils::new_object(user.id, project_id, ObjectType::PROJECT);
-    project.endpoints = Json(DashMap::from_iter([(endpoint1.clone(), true)]));
+    project.endpoints = Json(DashMap::from_iter([(endpoint1, true)]));
 
     let mut collection = test_utils::new_object(user.id, collection_id, ObjectType::COLLECTION);
-    collection.endpoints = Json(DashMap::from_iter([
-        (endpoint1.clone(), true),
-        (endpoint2.clone(), false),
-    ]));
+    collection.endpoints = Json(DashMap::from_iter([(endpoint1, true), (endpoint2, false)]));
 
     let mut object = test_utils::new_object(user.id, object_id, ObjectType::OBJECT);
-    object.endpoints = Json(DashMap::from_iter([
-        (endpoint1.clone(), true),
-        (endpoint2.clone(), false),
-    ]));
+    object.endpoints = Json(DashMap::from_iter([(endpoint1, true), (endpoint2, false)]));
 
     Object::batch_create(
         &vec![project.clone(), collection.clone(), object.clone()],
@@ -771,7 +765,7 @@ async fn add_remove_endpoint_test() {
         .unwrap();
 
     // Validate resources have a single endpoint
-    for resource_id in vec![project_id, collection_id, object_id] {
+    for resource_id in [project_id, collection_id, object_id] {
         let resource = Object::get(resource_id, client).await.unwrap().unwrap();
 
         if resource.id == project_id {
@@ -808,7 +802,7 @@ async fn add_remove_endpoint_test() {
         .unwrap();
 
     for resource in resources {
-        if vec![project_id, collection_id, object_id].contains(&resource.id) {
+        if [project_id, collection_id, object_id].contains(&resource.id) {
             assert_eq!(resource.endpoints.0.len(), 1);
             assert!(resource.endpoints.0.contains_key(&endpoint1));
         }
@@ -822,7 +816,7 @@ async fn add_remove_endpoint_test() {
     assert!(object.endpoints.0.contains_key(&endpoint1));
 
     // Try to remove last remaining endpoint --> Error
-    for resource_id in vec![project_id, collection_id, object_id] {
+    for resource_id in [project_id, collection_id, object_id] {
         let resource = Object::remove_endpoint(client, &resource_id, &endpoint1)
             .await
             .unwrap();

--- a/tests/database/users.rs
+++ b/tests/database/users.rs
@@ -761,7 +761,6 @@ async fn add_remove_trusted_endpoint_test() {
         .await
         .unwrap();
 
-    assert_eq!(users.len(), 3);
     for user in users {
         if user.id == user1_ulid {
             assert_eq!(user.attributes.0.trusted_endpoints.len(), 2);
@@ -781,7 +780,6 @@ async fn add_remove_trusted_endpoint_test() {
         .await
         .unwrap();
 
-    assert_eq!(users.len(), 3);
     for user in users {
         if user.id == user1_ulid || user.id == user2_ulid {
             assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
@@ -797,7 +795,6 @@ async fn add_remove_trusted_endpoint_test() {
         .await
         .unwrap();
 
-    assert_eq!(users.len(), 3);
     for user in users {
         if user.id == user1_ulid || user.id == user2_ulid {
             assert_eq!(user.attributes.0.trusted_endpoints.len(), 0)

--- a/tests/database/users.rs
+++ b/tests/database/users.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::common::{init, test_utils::USER1_ULID};
+use crate::common::{
+    init,
+    test_utils::{ADMIN_USER_ULID, USER1_ULID, USER2_ULID},
+};
 use aruna_server::database::{
     crud::CrudDb,
     dsls::{
@@ -688,4 +691,125 @@ async fn add_token_test() {
     .unwrap();
 
     //ToDo extend test
+}
+
+#[tokio::test]
+async fn add_remove_trusted_endpoint_test() {
+    let db = init::init_database().await;
+    let client = db.get_client().await.unwrap();
+    let client = client.client();
+
+    let user1_ulid = DieselUlid::from_str(USER1_ULID).unwrap();
+    let user2_ulid = DieselUlid::from_str(USER2_ULID).unwrap();
+    let sentinel_user_ulid = DieselUlid::from_str(ADMIN_USER_ULID).unwrap();
+
+    let endpoint1 = DieselUlid::generate();
+    let endpoint2 = DieselUlid::generate();
+    let endpoint3 = DieselUlid::generate();
+
+    // Add first endpoint to user1
+    let user1 = User::add_trusted_endpoint(client, &user1_ulid, &endpoint1)
+        .await
+        .unwrap();
+    assert_eq!(user1.attributes.0.trusted_endpoints.len(), 1);
+    assert!(user1
+        .attributes
+        .0
+        .trusted_endpoints
+        .contains_key(&endpoint1));
+
+    // Add second endpoint to user1
+    let user1 = User::add_trusted_endpoint(client, &user1_ulid, &endpoint2)
+        .await
+        .unwrap();
+    assert_eq!(user1.attributes.0.trusted_endpoints.len(), 2);
+    assert!(user1
+        .attributes
+        .0
+        .trusted_endpoints
+        .contains_key(&endpoint1));
+    assert!(user1
+        .attributes
+        .0
+        .trusted_endpoints
+        .contains_key(&endpoint2));
+
+    // Add first endpoint to user2
+    let user2 = User::add_trusted_endpoint(client, &user2_ulid, &endpoint2)
+        .await
+        .unwrap();
+    assert_eq!(user2.attributes.0.trusted_endpoints.len(), 1);
+    assert!(user2
+        .attributes
+        .0
+        .trusted_endpoints
+        .contains_key(&endpoint2));
+
+    // Add totem endpoint to admin user
+    let sentinel_user = User::add_trusted_endpoint(client, &sentinel_user_ulid, &endpoint3)
+        .await
+        .unwrap();
+    assert_eq!(sentinel_user.attributes.0.trusted_endpoints.len(), 1);
+    assert!(sentinel_user
+        .attributes
+        .0
+        .trusted_endpoints
+        .contains_key(&endpoint3));
+
+    // Remove non-existing endpoint
+    let users = User::remove_endpoint_from_users(client, &DieselUlid::generate())
+        .await
+        .unwrap();
+
+    assert_eq!(users.len(), 3);
+    for user in users {
+        if user.id == user1_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 2);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint1));
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint2))
+        } else if user.id == user2_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint2))
+        } else if user.id == sentinel_user_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint3))
+        }
+    }
+
+    // Remove first endpoint
+    let users = User::remove_endpoint_from_users(client, &endpoint1)
+        .await
+        .unwrap();
+
+    assert_eq!(users.len(), 3);
+    for user in users {
+        if user.id == user1_ulid || user.id == user2_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint2))
+        } else if user.id == sentinel_user_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint3))
+        }
+    }
+
+    // Remove second endpoint
+    let users = User::remove_endpoint_from_users(client, &endpoint2)
+        .await
+        .unwrap();
+
+    assert_eq!(users.len(), 3);
+    for user in users {
+        if user.id == user1_ulid || user.id == user2_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 0)
+        } else if user.id == sentinel_user_ulid {
+            assert_eq!(user.attributes.0.trusted_endpoints.len(), 1);
+            assert!(user.attributes.0.trusted_endpoints.contains_key(&endpoint3))
+        }
+    }
+
+    // Remove single endpoint from test_user
+    let totem_user = User::remove_trusted_endpoint(client, &sentinel_user_ulid, &endpoint3)
+        .await
+        .unwrap();
+    assert_eq!(totem_user.attributes.0.trusted_endpoints.len(), 0)
 }


### PR DESCRIPTION
This PR extends the removal of endpoints. 


The following additional steps are taken when an endpoint is completely removed from the AOS system:

* Removal of the endpoint id from the `trusted_endpoints` attribute of all users
* Removal of the endpoint from all objects (equivalent to the removal of the object replica at this endpoint)

Warning: If an object only has a replica of its data at this one endpoint, this data is lost when the endpoint is removed!