### PR TITLE
fix: Fixed get_resource(s) permission handling

### DIFF
--- a/tests/grpc/search.rs
+++ b/tests/grpc/search.rs
@@ -1,17 +1,24 @@
 use std::str::FromStr;
 
-use aruna_rust_api::api::storage::services::v2::{
-    search_service_server::SearchService, user_service_server::UserService,
-    GetPersonalNotificationsRequest, PersonalNotificationVariant, Reference, ReferenceType,
-    RequestResourceAccessRequest,
+use aruna_rust_api::api::storage::{
+    models::v2::DataClass,
+    services::v2::{
+        collection_service_server::CollectionService, project_service_server::ProjectService,
+        search_service_server::SearchService, user_service_server::UserService,
+        CreateCollectionRequest, CreateProjectRequest, GetPersonalNotificationsRequest,
+        GetResourceRequest, GetResourcesRequest, PersonalNotificationVariant, Reference,
+        ReferenceType, RequestResourceAccessRequest,
+    },
 };
-use aruna_server::database::enums::ObjectType;
+use aruna_server::database::{dsls::license_dsl::ALL_RIGHTS_RESERVED, enums::ObjectType};
 use diesel_ulid::DieselUlid;
+use tonic::Request;
 
 use crate::common::{
     init::init_service_block,
     test_utils::{
-        add_token, fast_track_grpc_project_create, USER1_OIDC_TOKEN, USER2_OIDC_TOKEN, USER2_ULID,
+        add_token, fast_track_grpc_collection_create, fast_track_grpc_project_create, rand_string,
+        USER1_OIDC_TOKEN, USER1_ULID, USER2_OIDC_TOKEN, USER2_ULID,
     },
 };
 
@@ -113,4 +120,309 @@ async fn grpc_request_access() {
     if !validated {
         panic!("Revoked permission personal notification does not exist")
     }
+}
+#[tokio::test]
+async fn get_resource() {
+    // ------------------- INIT -----------------------
+    let service_block = init_service_block().await;
+
+    // Create public project
+    let create_request = CreateProjectRequest {
+        name: rand_string(32).to_lowercase(),
+        description: "".to_string(),
+        key_values: vec![],
+        relations: vec![],
+        data_class: DataClass::Public as i32,
+        default_data_license_tag: ALL_RIGHTS_RESERVED.to_string(),
+        metadata_license_tag: ALL_RIGHTS_RESERVED.to_string(),
+        preferred_endpoint: "".to_string(),
+    };
+    let grpc_request = add_token(Request::new(create_request), USER1_OIDC_TOKEN);
+    let public_project = service_block
+        .project_service
+        .create_project(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .project
+        .unwrap();
+
+    // Create private project and collection
+    let private_project =
+        fast_track_grpc_project_create(&service_block.project_service, USER1_OIDC_TOKEN).await;
+    let parent =
+        aruna_rust_api::api::storage::services::v2::create_collection_request::Parent::ProjectId(
+            private_project.id.to_string(),
+        );
+    let private_collection = fast_track_grpc_collection_create(
+        &service_block.collection_service,
+        USER1_OIDC_TOKEN,
+        parent.clone(),
+    )
+    .await;
+
+    // Create confidential collection
+    let create_request = CreateCollectionRequest {
+        name: rand_string(32),
+        description: "".to_string(),
+        key_values: vec![],
+        relations: vec![],
+        data_class: DataClass::Confidential as i32,
+        parent: Some(parent),
+        default_data_license_tag: Some(ALL_RIGHTS_RESERVED.to_string()),
+        metadata_license_tag: Some(ALL_RIGHTS_RESERVED.to_string()),
+    };
+    let grpc_request = add_token(Request::new(create_request), USER1_OIDC_TOKEN);
+    let confidential_collection = service_block
+        .collection_service
+        .create_collection(grpc_request)
+        .await
+        .unwrap()
+        .into_inner()
+        .collection
+        .unwrap();
+
+    // ------------------- TESTS ----------------------------------
+    //
+    // Test access without permissions and token
+    //
+    let public_request = GetResourceRequest {
+        resource_id: public_project.id.to_string(),
+    };
+    let response = service_block
+        .search_service
+        .get_resource(tonic::Request::new(public_request.clone()))
+        .await
+        .unwrap()
+        .into_inner()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap();
+    let project = match response {
+        aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(project) => {
+            project
+        }
+        _ => panic!("This should be a project"),
+    };
+    // Should contain created by and endpoint
+    assert_eq!(project.created_by, public_project.created_by.to_string());
+    assert_eq!(project.endpoints, public_project.endpoints);
+
+    // Should not contain created_by and endpoint
+    let private_request = GetResourcesRequest {
+        resource_ids: vec![
+            private_project.id.to_string(),
+            private_collection.id.to_string(),
+        ],
+    };
+    let response = service_block
+        .search_service
+        .get_resources(tonic::Request::new(private_request.clone()))
+        .await
+        .unwrap()
+        .into_inner()
+        .resources;
+    let project = response
+        .iter()
+        .find_map(
+            |res| match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(
+                    proj,
+                ) => Some(proj),
+                _ => None,
+            },
+        )
+        .unwrap();
+    let collection =
+        response
+            .iter()
+            .find_map(|res| {
+                match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Collection(
+                   col
+                ) => Some(col),
+                _ => None,
+            }
+            })
+            .unwrap();
+    assert!(project.endpoints.is_empty());
+    assert_eq!(project.created_by, DieselUlid::default().to_string());
+    assert!(collection.endpoints.is_empty());
+    assert_eq!(collection.created_by, DieselUlid::default().to_string());
+
+    // This should error with permission denied
+    let confidential_request = GetResourceRequest {
+        resource_id: confidential_collection.id.to_string(),
+    };
+    let response = service_block
+        .search_service
+        .get_resource(tonic::Request::new(confidential_request.clone()))
+        .await;
+    assert!(response.is_err());
+
+    //
+    // Test with token and without permissions
+    //
+    let response = service_block
+        .search_service
+        .get_resource(add_token(
+            tonic::Request::new(public_request.clone()),
+            USER2_OIDC_TOKEN,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap();
+    let project = match response {
+        aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(project) => {
+            project
+        }
+        _ => panic!("This should be a project"),
+    };
+
+    // Same as above
+    assert_eq!(project.created_by, public_project.created_by.to_string());
+    assert_eq!(project.endpoints, public_project.endpoints);
+    let response = service_block
+        .search_service
+        .get_resources(add_token(
+            tonic::Request::new(private_request.clone()),
+            USER2_OIDC_TOKEN,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .resources;
+    let project = response
+        .iter()
+        .find_map(
+            |res| match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(
+                    proj,
+                ) => Some(proj),
+                _ => None,
+            },
+        )
+        .unwrap();
+    let collection =
+        response
+            .iter()
+            .find_map(|res| {
+                match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Collection(
+                   col
+                ) => Some(col),
+                _ => None,
+            }
+            })
+            .unwrap();
+    assert!(project.endpoints.is_empty());
+    assert_eq!(project.created_by, DieselUlid::default().to_string());
+    assert!(collection.endpoints.is_empty());
+    assert_eq!(collection.created_by, DieselUlid::default().to_string());
+    let response = service_block
+        .search_service
+        .get_resource(add_token(
+            tonic::Request::new(confidential_request.clone()),
+            USER2_OIDC_TOKEN,
+        ))
+        .await;
+    assert!(response.is_err());
+
+    //
+    // Test with token and permissions
+    //
+    let response = service_block
+        .search_service
+        .get_resource(add_token(
+            tonic::Request::new(public_request),
+            USER1_OIDC_TOKEN,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap();
+    let project = match response {
+        aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(project) => {
+            project
+        }
+        _ => panic!("This should be a project"),
+    };
+
+    // Same as above
+    assert_eq!(project.created_by, public_project.created_by.to_string());
+    assert_eq!(project.endpoints, public_project.endpoints);
+    let response = service_block
+        .search_service
+        .get_resources(add_token(
+            tonic::Request::new(private_request),
+            USER1_OIDC_TOKEN,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .resources;
+    let project = response
+        .iter()
+        .find_map(
+            |res| match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Project(
+                    proj,
+                ) => Some(proj),
+                _ => None,
+            },
+        )
+        .unwrap();
+    let collection =
+        response
+            .iter()
+            .find_map(|res| {
+                match res.resource.as_ref().unwrap().resource.as_ref().unwrap() {
+                aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Collection(
+                   col
+                ) => Some(col),
+                _ => None,
+            }
+            })
+            .unwrap();
+    assert!(!project.endpoints.is_empty());
+    assert_eq!(project.created_by, USER1_ULID);
+    assert!(!collection.endpoints.is_empty());
+    assert_eq!(collection.created_by, USER1_ULID);
+    let response = service_block
+        .search_service
+        .get_resource(add_token(
+            tonic::Request::new(confidential_request),
+            USER1_OIDC_TOKEN,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap()
+        .resource
+        .unwrap();
+    let confidential_collection = match response {
+        aruna_rust_api::api::storage::models::v2::generic_resource::Resource::Collection(col) => {
+            col
+        }
+        _ => panic!("This should be a collection"),
+    };
+    assert!(!confidential_collection.endpoints.is_empty());
+    assert_eq!(confidential_collection.created_by, USER1_ULID);
 }


### PR DESCRIPTION
This PR fixes permission handling for `get_resource` and `get_resources` in `grpc/search.rs`.