### PR TITLE
Fix deleted resources permission handling

### DIFF
--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -608,7 +608,7 @@ impl Cache {
 
         while let Some(x) = queue.pop_front() {
             if let Some(x) = self.get_object(&x) {
-                for child in x.get_children() {
+                for child in x.get_permission_children() {
                     if let Some(got_perm) = ctxs.remove(&child) {
                         if got_perm > perm {
                             bail!("Invalid permissions")

--- a/src/middlelayer/delete_db_handler.rs
+++ b/src/middlelayer/delete_db_handler.rs
@@ -28,7 +28,7 @@ impl DatabaseHandler {
         let (object_ids_to_delete, relation_ids_to_delete, affected_resources) =
             match delete_request {
                 DeleteRequest::Object(request) => {
-                    //  - Set all outbound 'BELONGS_TO' relations to 'DELETED'
+                    //  - Set all inbound 'BELONGS_TO' relations to 'DELETED'
                     //  - Set object_status to 'DELETED'
                     //  - if 'with_revisions: true' repeat for all versions
                     let mut objects = vec![root_object.clone()];
@@ -67,8 +67,8 @@ impl DatabaseHandler {
                         o.get_parents().into_iter().for_each(|p| {
                             affected_resources.insert(p);
                         });
-                        // Collect relations for deletion
-                        o.outbound_belongs_to
+                        // Collect relations to parents for deletion
+                        o.inbound_belongs_to
                             .0
                             .iter()
                             .for_each(|entry| relation_ids.push(entry.value().id))

--- a/src/middlelayer/delete_db_handler.rs
+++ b/src/middlelayer/delete_db_handler.rs
@@ -117,9 +117,7 @@ impl DatabaseHandler {
                                 if resource.object.id != root_object.object.id {
                                     for parent_id in resource.get_parents() {
                                         if !(ids_to_delete.contains(&parent_id)) {
-                                            bail!(
-                                                "Object has parents outside the deletion hierarchy"
-                                            )
+                                            bail!("Resource {} still has parents in multiple hierarchies", resource.object.id)
                                         }
                                     }
                                 } else {
@@ -161,8 +159,11 @@ impl DatabaseHandler {
                             }
                             ObjectType::OBJECT => {
                                 for parent_id in resource.get_parents() {
-                                    if ids_to_delete.contains(&parent_id) {
-                                        bail!("Object has parents outside the deletion hierarchy")
+                                    if !ids_to_delete.contains(&parent_id) {
+                                        bail!(
+                                            "Resource {} still has parents in multiple hierarchies",
+                                            resource.object.id
+                                        )
                                     }
                                 }
                                 ids_to_delete.insert(resource.object.id);

--- a/src/middlelayer/hooks_db_handler.rs
+++ b/src/middlelayer/hooks_db_handler.rs
@@ -183,7 +183,6 @@ impl DatabaseHandler {
         triggers: Vec<TriggerVariant>,
         updated_labels: Option<Vec<KeyValue>>,
     ) -> Result<()> {
-        dbg!("Trigger hooks started");
         let client = self.database.get_client().await?;
         let parents = self.cache.upstream_dfs_iterative(&object.object.id)?;
         let projects = DatabaseHandler::collect_projects(parents);

--- a/tests/database/stats.rs
+++ b/tests/database/stats.rs
@@ -62,7 +62,7 @@ async fn general_object_stats_test() {
     // Assert that refresh can be started
     // Needs the loop as the first Materialized View refresh, which also creates the table,
     // can fail with a "Restarting a DDL transaction not supported" error.
-    while let Err(_) = refresh_stats(&client).await {
+    while refresh_stats(&client).await.is_err() {
         // Test will timeout if refresh start fails long enough
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -94,7 +94,7 @@ async fn general_object_stats_test() {
 
     // Assert that get_all_stats().len() > 0
     let all_stats = ObjectStats::get_all_stats(&client).await.unwrap();
-    assert!(all_stats.len() > 0);
+    assert!(!all_stats.is_empty());
 
     // Assert that last timestamp is greater than timestamp at the start of the test
     let last_timestamp = get_last_refresh(&client).await.unwrap().timestamp_millis();

--- a/tests/middlelayer/delete.rs
+++ b/tests/middlelayer/delete.rs
@@ -249,7 +249,7 @@ async fn delete_hierarchies() {
         &vec![
             p1_c1, p1_c2, p2_c2, c1_d1, c2_d1, c2_d2, d1_o1, d1_o2, d2_o2, d2_o3,
         ],
-        &client,
+        client,
     )
     .await
     .unwrap();
@@ -361,7 +361,7 @@ async fn delete_hierarchies() {
         assert_eq!(&del_rel.1.relation_name, "DELETED")
     }
 
-    for resource_id in vec![&collection_02.id, &dataset_02.id] {
+    for resource_id in [&collection_02.id, &dataset_02.id] {
         let del_obj = db_handler.cache.get_object(resource_id).unwrap();
         assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
         assert!(del_obj.inbound_belongs_to.0.is_empty());
@@ -404,7 +404,7 @@ async fn delete_hierarchies() {
     assert_eq!(del_obj.outbound.0.len(), 2);
     for del_rel in del_obj.inbound.0 {
         assert_eq!(del_rel.1.origin_pid, project_01.id);
-        assert!(vec![collection_01.id, collection_02.id].contains(&del_rel.1.target_pid));
+        assert!([collection_01.id, collection_02.id].contains(&del_rel.1.target_pid));
         assert_eq!(&del_rel.1.relation_name, "DELETED")
     }
 

--- a/tests/middlelayer/delete.rs
+++ b/tests/middlelayer/delete.rs
@@ -1,5 +1,5 @@
 use crate::common::init::init_database_handler_middlelayer;
-use crate::common::test_utils;
+use crate::common::test_utils::{self, new_internal_relation, new_object};
 use aruna_rust_api::api::storage::services::v2::{
     DeleteCollectionRequest, DeleteDatasetRequest, DeleteObjectRequest, DeleteProjectRequest,
 };
@@ -154,11 +154,22 @@ async fn delete_object() {
         .unwrap();
 
     // Test request
-    let delete_request = DeleteRequest::Object(DeleteObjectRequest {
+    let mut inner_request = DeleteObjectRequest {
         object_id: object_id.to_string(),
-        with_revisions: true,
-    });
-    db_handler.delete_resource(delete_request).await.unwrap();
+        with_revisions: false,
+    };
+
+    let result = db_handler
+        .delete_resource(DeleteRequest::Object(inner_request.clone()))
+        .await;
+    assert!(result.is_err()); // Undeleted versions exist
+
+    inner_request.with_revisions = true;
+    db_handler
+        .delete_resource(DeleteRequest::Object(inner_request))
+        .await
+        .unwrap();
+
     assert_eq!(
         Object::get(object_id, client)
             .await
@@ -183,4 +194,235 @@ async fn delete_object() {
             .object_status,
         ObjectStatus::DELETED
     );
+}
+
+#[tokio::test]
+async fn delete_hierarchies() {
+    // Middle layer
+    let db_handler = init_database_handler_middlelayer().await;
+    let client = &db_handler.database.get_client().await.unwrap();
+
+    // Init user
+    let mut user = test_utils::new_user(vec![]);
+    user.create(client).await.unwrap();
+
+    // Create hierarchy
+    let project_01 = new_object(user.id, DieselUlid::generate(), ObjectType::PROJECT);
+    let project_02 = new_object(user.id, DieselUlid::generate(), ObjectType::PROJECT);
+    let collection_01 = new_object(user.id, DieselUlid::generate(), ObjectType::COLLECTION);
+    let collection_02 = new_object(user.id, DieselUlid::generate(), ObjectType::COLLECTION);
+    let dataset_01 = new_object(user.id, DieselUlid::generate(), ObjectType::DATASET);
+    let dataset_02 = new_object(user.id, DieselUlid::generate(), ObjectType::DATASET);
+    let object_01 = new_object(user.id, DieselUlid::generate(), ObjectType::OBJECT);
+    let object_02 = new_object(user.id, DieselUlid::generate(), ObjectType::OBJECT);
+    let object_03 = new_object(user.id, DieselUlid::generate(), ObjectType::OBJECT);
+
+    let p1_c1 = new_internal_relation(&project_01, &collection_01);
+    let p1_c2 = new_internal_relation(&project_01, &collection_02);
+    let p2_c2 = new_internal_relation(&project_02, &collection_02);
+    let c1_d1 = new_internal_relation(&collection_01, &dataset_01);
+    let c2_d1 = new_internal_relation(&collection_02, &dataset_01);
+    let c2_d2 = new_internal_relation(&collection_02, &dataset_02);
+    let d1_o1 = new_internal_relation(&dataset_01, &object_01);
+    let d1_o2 = new_internal_relation(&dataset_01, &object_02);
+    let d2_o2 = new_internal_relation(&dataset_02, &object_02);
+    let d2_o3 = new_internal_relation(&dataset_02, &object_03);
+
+    Object::batch_create(
+        &vec![
+            project_01.clone(),
+            project_02,
+            collection_01.clone(),
+            collection_02.clone(),
+            dataset_01.clone(),
+            dataset_02.clone(),
+            object_01.clone(),
+            object_02.clone(),
+            object_03.clone(),
+        ],
+        client,
+    )
+    .await
+    .unwrap();
+
+    InternalRelation::batch_create(
+        &vec![
+            p1_c1, p1_c2, p2_c2, c1_d1, c2_d1, c2_d2, d1_o1, d1_o2, d2_o2, d2_o3,
+        ],
+        &client,
+    )
+    .await
+    .unwrap();
+
+    // Sync cache with database
+    db_handler
+        .cache
+        .sync_cache(db_handler.database.clone())
+        .await
+        .unwrap();
+
+    // Delete object_01
+    //  - Assert object_status is DELETED
+    //  - Assert inbound_belongs_to and outbound_belongs_to is empty
+    //  - Assert inbound contains DELETED relation to parent
+    let deleted_resources = db_handler
+        .delete_resource(DeleteRequest::Object(DeleteObjectRequest {
+            object_id: object_01.id.to_string(),
+            with_revisions: false,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(deleted_resources.len(), 1); // Only object deleted
+
+    let del_obj = db_handler.cache.get_object(&object_01.id).unwrap(); // deleted_objects.first().unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound.0.is_empty());
+
+    assert_eq!(del_obj.inbound.0.len(), 1);
+    for del_rel in del_obj.inbound.0 {
+        assert_eq!(del_rel.1.origin_pid, dataset_01.id);
+        assert_eq!(del_rel.1.target_pid, object_01.id);
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+
+    // Try delete dataset_01 -> Error(object_02 has multiple parents)
+    let result = db_handler
+        .delete_resource(DeleteRequest::Dataset(DeleteDatasetRequest {
+            dataset_id: dataset_01.id.to_string(),
+        }))
+        .await;
+    assert!(result.is_err());
+
+    // Delete object_02
+    let deleted_resources = db_handler
+        .delete_resource(DeleteRequest::Object(DeleteObjectRequest {
+            object_id: object_02.id.to_string(),
+            with_revisions: false,
+        }))
+        .await
+        .unwrap();
+    assert_eq!(deleted_resources.len(), 1);
+
+    let del_obj = db_handler.cache.get_object(&object_02.id).unwrap(); // deleted_objects.first().unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+
+    // Delete dataset_01
+    //  - Assert dataset_01 object_status is DELETED
+    //  - Assert inbound_belongs_to and outbound_belongs_to is empty
+    //  - Assert relations parents and children are DELETED
+    let deleted_objects = db_handler
+        .delete_resource(DeleteRequest::Dataset(DeleteDatasetRequest {
+            dataset_id: dataset_01.id.to_string(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(deleted_objects.len(), 1); // Only dataset got deleted
+
+    let del_obj = db_handler.cache.get_object(&dataset_01.id).unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+
+    assert_eq!(del_obj.inbound.0.len(), 2);
+    for del_rel in del_obj.inbound.0 {
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+    assert_eq!(del_obj.outbound.0.len(), 2);
+    for del_rel in del_obj.outbound.0 {
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+
+    // Delete collection_02
+    //  - Assert collection_02 status is DELETED
+    //  - Assert inbound_belongs_to and outbound_belongs_to is empty
+    //  - Assert relations to dataset_01, dataset_02 and project_02 are DELETED
+    let deleted_objects = db_handler
+        .delete_resource(DeleteRequest::Dataset(DeleteDatasetRequest {
+            dataset_id: collection_02.id.to_string(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(deleted_objects.len(), 3); // collection_02, dataset_02 and object_03
+
+    let del_obj = db_handler.cache.get_object(&object_03.id).unwrap(); // deleted_objects.first().unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound.0.is_empty());
+
+    assert_eq!(del_obj.inbound.0.len(), 1);
+    for del_rel in del_obj.inbound.0 {
+        assert_eq!(del_rel.1.origin_pid, dataset_02.id);
+        assert_eq!(del_rel.1.target_pid, object_03.id);
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+
+    for resource_id in vec![&collection_02.id, &dataset_02.id] {
+        let del_obj = db_handler.cache.get_object(resource_id).unwrap();
+        assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+        assert!(del_obj.inbound_belongs_to.0.is_empty());
+        assert!(del_obj.outbound_belongs_to.0.is_empty());
+
+        assert_eq!(
+            del_obj.inbound.0.len(),
+            if resource_id == &collection_02.id {
+                2
+            } else {
+                1
+            }
+        );
+        for del_rel in del_obj.inbound.0 {
+            assert_eq!(&del_rel.1.relation_name, "DELETED")
+        }
+        assert_eq!(del_obj.outbound.0.len(), 2);
+        for del_rel in del_obj.outbound.0 {
+            assert_eq!(&del_rel.1.relation_name, "DELETED")
+        }
+    }
+
+    // Delete project_01
+    //  - Assert project_01 status is DELETED
+    //  - Assert inbound_belongs_to and outbound_belongs_to is empty
+    let deleted_objects = db_handler
+        .delete_resource(DeleteRequest::Dataset(DeleteDatasetRequest {
+            dataset_id: project_01.id.to_string(),
+        }))
+        .await
+        .unwrap();
+    assert_eq!(deleted_objects.len(), 2); // project_01, collection_01
+
+    let del_obj = db_handler.cache.get_object(&project_01.id).unwrap(); // deleted_objects.first().unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+    assert!(del_obj.inbound.0.is_empty());
+
+    assert_eq!(del_obj.outbound.0.len(), 2);
+    for del_rel in del_obj.inbound.0 {
+        assert_eq!(del_rel.1.origin_pid, project_01.id);
+        assert!(vec![collection_01.id, collection_02.id].contains(&del_rel.1.target_pid));
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+
+    let del_obj = db_handler.cache.get_object(&collection_01.id).unwrap();
+    assert_eq!(del_obj.object.object_status, ObjectStatus::DELETED);
+    assert!(del_obj.inbound_belongs_to.0.is_empty());
+    assert!(del_obj.outbound_belongs_to.0.is_empty());
+
+    assert_eq!(del_obj.inbound.0.len(), 1);
+    for del_rel in del_obj.inbound.0 {
+        assert_eq!(del_rel.1.origin_pid, project_01.id);
+        assert_eq!(del_rel.1.target_pid, collection_01.id);
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
+    assert_eq!(del_obj.outbound.0.len(), 1);
+    for del_rel in del_obj.outbound.0 {
+        assert_eq!(del_rel.1.origin_pid, collection_01.id);
+        assert_eq!(del_rel.1.target_pid, dataset_01.id);
+        assert_eq!(&del_rel.1.relation_name, "DELETED")
+    }
 }


### PR DESCRIPTION
# Deleted resources permission handling

Changes to the resource deletion concept had the unintended effect of removing deleted resources from permission handling. As a result, deleted resources could no longer be requested by users at all.

This PR fixes two bugs directly involved in the deletion handling process and resolves #142.